### PR TITLE
Remove log call

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/url"
 
 	"github.com/andreykaipov/goobs/api/events"
@@ -82,8 +81,7 @@ func New(host string, opts ...Option) (*Client, error) {
 func (c *Client) connect() (err error) {
 	u := url.URL{Scheme: "ws", Host: c.host}
 
-	log.Printf("connecting to %s", u.String())
-
+	// log.Printf("connecting to %s", u.String())
 	if c.Conn, _, err = websocket.DefaultDialer.Dial(u.String(), nil); err != nil {
 		return err
 	}


### PR DESCRIPTION
This being a library we should prevent logging (per default). Since this is the only log call currently I've decided to simply comment it out. If we want to use a logger, we need to provide a way for the library's user to overwrite the logger.