### PR TITLE
Add Go build/test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: build
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        go-version: [~1.11, ^1]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      GO111MODULE: "on"
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,27 @@
+name: generate
+on: [push, pull_request]
+
+jobs:
+  generate:
+    strategy:
+      matrix:
+        go-version: [^1]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Generate
+        run: make generate
+
+      - name: Build
+        run: go build -v ./...


### PR DESCRIPTION
Adds two GitHub Action workflow that run for every push and pull request.

The first one tries to build the entire project on Ubuntu, macOS, and Windows for Go 1.11 (minimum required version) as well as the latest available Go version (at the time of the action being run). It will also run `go test` should we have test cases in the future. Currently it will just silently pass as it doesn't find any.

The second one runs the generator (`make generate`) on Ubuntu and tries to build the project with the freshly generated sources.