### PR TITLE
Improves error handling

### DIFF
--- a/api/requests/client.go
+++ b/api/requests/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/andreykaipov/goobs/api/events"
 	"github.com/gorilla/websocket"
 	uuid "github.com/nu7hatch/gouuid"
 )
@@ -27,7 +28,10 @@ type Client struct {
 	// The time we're willing to wait to receive a response from the server.
 	ResponseTimeout time.Duration
 
-	// Raw JSON message responses from the websocker server.
+	// Events broadcast by the server when actions happen within OBS.
+	IncomingEvents chan events.Event
+
+	// Raw JSON message responses from the websocket server.
 	IncomingResponses chan json.RawMessage
 
 	Log Logger
@@ -39,6 +43,9 @@ open connection. You don't really have to do this as any connections should
 close when your program terminates or interrupts. But here's a function anyways.
 */
 func (c *Client) Disconnect() error {
+	close(c.IncomingResponses)
+	close(c.IncomingEvents)
+
 	return c.Conn.WriteMessage(
 		websocket.CloseMessage,
 		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),

--- a/api/requests/requests.go
+++ b/api/requests/requests.go
@@ -9,7 +9,7 @@ type Params interface {
 	SetMessageID(string)
 
 	// The name of the actual request, i.e. "Abc" for "AbcParams". Used to
-	// set the RequestType.
+	// set the RequestType, so it's essentially an alias for GetRequestType.
 	GetSelfName() string
 }
 

--- a/client.go
+++ b/client.go
@@ -21,9 +21,7 @@ var version = "0.8.0-dev"
 
 // Client represents a client to an OBS websockets server.
 type Client struct {
-	IncomingEvents chan events.Event
 	*requests.Client
-
 	subclients
 	host          string
 	password      string
@@ -236,6 +234,12 @@ func (c *Client) handleConnection(messages chan json.RawMessage, errors chan err
 	}
 }
 
+// Handles messages from the server. They might be response bodies associated
+// with requests, or they can be events we can subscribe to via the
+// `client.IncomingEvents` channel. Or they can be something totally else, in
+// which case we expose the errors as more events! Despite also handling
+// incoming responses, we refer to this loop as the "eventing loop" elsewhere in
+// the comments.
 func (c *Client) handleRawMessages(messages chan json.RawMessage, errors chan error) {
 	for raw := range messages {
 		// Parse into a generic map to figure out if it's an event or

--- a/client.go
+++ b/client.go
@@ -245,7 +245,7 @@ func (c *Client) handleRawMessages(messages chan json.RawMessage, errors chan er
 			continue
 		}
 
-		panic("idk what kinda message this is lol")
+		errors <- fmt.Errorf("Client/server version mismatch? Unrecognized message: %s", raw)
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/andreykaipov/goobs/api/events"
 	"github.com/andreykaipov/goobs/api/requests"
@@ -77,6 +78,15 @@ func WithRequestHeader(x http.Header) Option {
 	}
 }
 
+// WithResponseTimeout sets the time we're willing to wait to receive a response
+// from the server for any request, before responding with an error. It's in
+// milliseconds. The default timeout is 10 seconds.
+func WithResponseTimeout(x time.Duration) Option {
+	return func(o *Client) {
+		o.ResponseTimeout = time.Duration(x)
+	}
+}
+
 type discard struct{}
 
 func (o *discard) Printf(format string, v ...interface{}) {}
@@ -93,8 +103,10 @@ It also opens up a connection, so be sure to check the error.
 */
 func New(host string, opts ...Option) (*Client, error) {
 	c := &Client{
-		Client: &requests.Client{},
-		host:   host,
+		Client: &requests.Client{
+			ResponseTimeout: 10000,
+		},
+		host: host,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
Changes:

- Configurable timeout for responses. Should a request not receive a response after the timeout, we return an error.
   This is client-wide. Default is 10 seconds.
- Don't panic on unrecognized messages, rather expose as errors. Closes #22.
- Improves authentication error handling.
- Maintain the latest events broadcast by OBS in order. Still available via `client.IncomingEvents`. Previously this just stored the first 100 if they weren't yet consumed.

Plus just general housekeeping.