### PR TITLE
Add configurable underlying dialer and request header options

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/andreykaipov/goobs"
@@ -17,7 +18,13 @@ func check(err error) {
 }
 
 func Test_goobs_e2e(t *testing.T) {
-	client, err := goobs.New("localhost:4545", goobs.WithPassword("hello"))
+	client, err := goobs.New(
+		"localhost:4545",
+		goobs.WithPassword("hello"),
+		goobs.WithRequestHeader(http.Header{
+			"User-Agent": []string{"goobs-e2e/0.0.0"},
+		}),
+	)
 	assert.NoError(t, err)
 
 	sceneName := "goobs test scene"


### PR DESCRIPTION
Changes:

- Adds `WithDialer(x *websocket.Dialer)` and `WithRequestHeader(x http.Header)` options. Addresses #23.

- Sets the default request headers to have a user agent of `goobs/${version}`. Example log from OBS with this library now:

   ```[connect] WebSocket Connection 192.168.200.1:41272 v13 "goobs/0.8.0-dev" / 101```

   Note: This necessitates maintaining the library version within the code now. So, before a release, this should be updated to remove the `-dev` suffix, and then bumped up in preparation for the next release.