### PR TITLE
use pointers to bools

### DIFF
--- a/api/events/xx_generated.general.heartbeat.go
+++ b/api/events/xx_generated.general.heartbeat.go
@@ -18,16 +18,16 @@ type Heartbeat struct {
 	CurrentScene string `json:"current-scene,omitempty"`
 
 	// Toggles between every JSON message as an "I am alive" indicator.
-	Pulse bool `json:"pulse"`
+	Pulse *bool `json:"pulse,omitempty"`
 
 	// Current recording state.
-	Recording bool `json:"recording"`
+	Recording *bool `json:"recording,omitempty"`
 
 	// OBS Stats
 	Stats typedefs.OBSStats `json:"stats,omitempty"`
 
 	// Current streaming state.
-	Streaming bool `json:"streaming"`
+	Streaming *bool `json:"streaming,omitempty"`
 
 	// Total bytes recorded since the recording started.
 	TotalRecordBytes int `json:"total-record-bytes,omitempty"`

--- a/api/events/xx_generated.scene_items.sceneitemlockchanged.go
+++ b/api/events/xx_generated.scene_items.sceneitemlockchanged.go
@@ -13,7 +13,7 @@ type SceneItemLockChanged struct {
 	ItemId int `json:"item-id,omitempty"`
 
 	// New locked state of the item.
-	ItemLocked bool `json:"item-locked"`
+	ItemLocked *bool `json:"item-locked,omitempty"`
 
 	// Name of the item in the scene.
 	ItemName string `json:"item-name,omitempty"`

--- a/api/events/xx_generated.scene_items.sceneitemvisibilitychanged.go
+++ b/api/events/xx_generated.scene_items.sceneitemvisibilitychanged.go
@@ -16,7 +16,7 @@ type SceneItemVisibilityChanged struct {
 	ItemName string `json:"item-name,omitempty"`
 
 	// New visibility state of the item.
-	ItemVisible bool `json:"item-visible"`
+	ItemVisible *bool `json:"item-visible,omitempty"`
 
 	// Name of the scene.
 	SceneName string `json:"scene-name,omitempty"`

--- a/api/events/xx_generated.sources.sourceaudiomixerschanged.go
+++ b/api/events/xx_generated.sources.sourceaudiomixerschanged.go
@@ -20,7 +20,7 @@ type SourceAudioMixersChanged struct {
 
 type Mixer struct {
 	// Routing status
-	Enabled bool `json:"enabled"`
+	Enabled *bool `json:"enabled,omitempty"`
 
 	// Mixer number
 	Id int `json:"id,omitempty"`

--- a/api/events/xx_generated.sources.sourcefiltervisibilitychanged.go
+++ b/api/events/xx_generated.sources.sourcefiltervisibilitychanged.go
@@ -10,7 +10,7 @@ type SourceFilterVisibilityChanged struct {
 	EventBasic
 
 	// New filter state
-	FilterEnabled bool `json:"filterEnabled"`
+	FilterEnabled *bool `json:"filterEnabled,omitempty"`
 
 	// Filter name
 	FilterName string `json:"filterName,omitempty"`

--- a/api/events/xx_generated.sources.sourcemutestatechanged.go
+++ b/api/events/xx_generated.sources.sourcemutestatechanged.go
@@ -10,7 +10,7 @@ type SourceMuteStateChanged struct {
 	EventBasic
 
 	// Mute status of the source
-	Muted bool `json:"muted"`
+	Muted *bool `json:"muted,omitempty"`
 
 	// Source name
 	SourceName string `json:"sourceName,omitempty"`

--- a/api/events/xx_generated.streaming.streamstarting.go
+++ b/api/events/xx_generated.streaming.streamstarting.go
@@ -10,5 +10,5 @@ type StreamStarting struct {
 	EventBasic
 
 	// Always false (retrocompatibility).
-	PreviewOnly bool `json:"preview-only"`
+	PreviewOnly *bool `json:"preview-only,omitempty"`
 }

--- a/api/events/xx_generated.streaming.streamstatus.go
+++ b/api/events/xx_generated.streaming.streamstatus.go
@@ -43,10 +43,10 @@ type StreamStatus struct {
 	OutputTotalFrames int `json:"output-total-frames,omitempty"`
 
 	// Always false (retrocompatibility).
-	PreviewOnly bool `json:"preview-only"`
+	PreviewOnly *bool `json:"preview-only,omitempty"`
 
 	// Current recording state.
-	Recording bool `json:"recording"`
+	Recording *bool `json:"recording,omitempty"`
 
 	// Number of frames missed due to rendering lag
 	RenderMissedFrames int `json:"render-missed-frames,omitempty"`
@@ -55,13 +55,13 @@ type StreamStatus struct {
 	RenderTotalFrames int `json:"render-total-frames,omitempty"`
 
 	// Replay Buffer status
-	ReplayBufferActive bool `json:"replay-buffer-active"`
+	ReplayBufferActive *bool `json:"replay-buffer-active,omitempty"`
 
 	// Percentage of dropped frames.
 	Strain float64 `json:"strain,omitempty"`
 
 	// Current streaming state.
-	Streaming bool `json:"streaming"`
+	Streaming *bool `json:"streaming,omitempty"`
 
 	// Total time (in seconds) since the stream started.
 	TotalStreamTime int `json:"total-stream-time,omitempty"`

--- a/api/events/xx_generated.streaming.streamstopping.go
+++ b/api/events/xx_generated.streaming.streamstopping.go
@@ -10,5 +10,5 @@ type StreamStopping struct {
 	EventBasic
 
 	// Always false (retrocompatibility).
-	PreviewOnly bool `json:"preview-only"`
+	PreviewOnly *bool `json:"preview-only,omitempty"`
 }

--- a/api/events/xx_generated.studio_mode.studiomodeswitched.go
+++ b/api/events/xx_generated.studio_mode.studiomodeswitched.go
@@ -10,5 +10,5 @@ type StudioModeSwitched struct {
 	EventBasic
 
 	// The new enabled state of Studio Mode.
-	NewState bool `json:"new-state"`
+	NewState *bool `json:"new-state,omitempty"`
 }

--- a/api/requests/general/xx_generated.executebatch.go
+++ b/api/requests/general/xx_generated.executebatch.go
@@ -13,7 +13,7 @@ type ExecuteBatchParams struct {
 	requests.ParamsBasic
 
 	// Stop processing batch requests if one returns a failure.
-	AbortOnFail bool `json:"abortOnFail"`
+	AbortOnFail *bool `json:"abortOnFail,omitempty"`
 
 	Requests []*Request `json:"requests,omitempty"`
 }

--- a/api/requests/general/xx_generated.getauthrequired.go
+++ b/api/requests/general/xx_generated.getauthrequired.go
@@ -29,7 +29,7 @@ type GetAuthRequiredResponse struct {
 	requests.ResponseBasic
 
 	// Indicates whether authentication is required.
-	AuthRequired bool `json:"authRequired"`
+	AuthRequired *bool `json:"authRequired,omitempty"`
 
 	Challenge string `json:"challenge,omitempty"`
 

--- a/api/requests/general/xx_generated.triggerhotkeybysequence.go
+++ b/api/requests/general/xx_generated.triggerhotkeybysequence.go
@@ -21,16 +21,16 @@ type TriggerHotkeyBySequenceParams struct {
 
 type KeyModifiers struct {
 	// Trigger Alt Key
-	Alt bool `json:"alt"`
+	Alt *bool `json:"alt,omitempty"`
 
 	// Trigger Command Key (Mac)
-	Command bool `json:"command"`
+	Command *bool `json:"command,omitempty"`
 
 	// Trigger Control (Ctrl) Key
-	Control bool `json:"control"`
+	Control *bool `json:"control,omitempty"`
 
 	// Trigger Shift Key
-	Shift bool `json:"shift"`
+	Shift *bool `json:"shift,omitempty"`
 }
 
 // GetSelfName just returns "TriggerHotkeyBySequence".

--- a/api/requests/media_control/xx_generated.playpausemedia.go
+++ b/api/requests/media_control/xx_generated.playpausemedia.go
@@ -14,7 +14,7 @@ type PlayPauseMediaParams struct {
 	requests.ParamsBasic
 
 	// (optional) Whether to pause or play the source. `false` for play, `true` for pause.
-	PlayPause bool `json:"playPause"`
+	PlayPause *bool `json:"playPause,omitempty"`
 
 	// Source name.
 	SourceName string `json:"sourceName,omitempty"`

--- a/api/requests/outputs/xx_generated.stopoutput.go
+++ b/api/requests/outputs/xx_generated.stopoutput.go
@@ -15,7 +15,7 @@ type StopOutputParams struct {
 	requests.ParamsBasic
 
 	// Force stop (default: false)
-	Force bool `json:"force"`
+	Force *bool `json:"force,omitempty"`
 
 	// Output name
 	OutputName string `json:"outputName,omitempty"`

--- a/api/requests/recording/xx_generated.getrecordingstatus.go
+++ b/api/requests/recording/xx_generated.getrecordingstatus.go
@@ -27,10 +27,10 @@ type GetRecordingStatusResponse struct {
 	requests.ResponseBasic
 
 	// Current recording status.
-	IsRecording bool `json:"isRecording"`
+	IsRecording *bool `json:"isRecording,omitempty"`
 
 	// Whether the recording is paused or not.
-	IsRecordingPaused bool `json:"isRecordingPaused"`
+	IsRecordingPaused *bool `json:"isRecordingPaused,omitempty"`
 
 	// Time elapsed since recording started (only present if currently recording).
 	RecordTimecode string `json:"recordTimecode,omitempty"`

--- a/api/requests/replay_buffer/xx_generated.getreplaybufferstatus.go
+++ b/api/requests/replay_buffer/xx_generated.getreplaybufferstatus.go
@@ -27,7 +27,7 @@ type GetReplayBufferStatusResponse struct {
 	requests.ResponseBasic
 
 	// Current recording status.
-	IsReplayBufferActive bool `json:"isReplayBufferActive"`
+	IsReplayBufferActive *bool `json:"isReplayBufferActive,omitempty"`
 }
 
 // GetReplayBufferStatus sends the corresponding request to the connected OBS WebSockets server. Note the variadic

--- a/api/requests/scene_items/xx_generated.addsceneitem.go
+++ b/api/requests/scene_items/xx_generated.addsceneitem.go
@@ -16,7 +16,7 @@ type AddSceneItemParams struct {
 	SceneName string `json:"sceneName,omitempty"`
 
 	// Whether to make the sceneitem visible on creation or not. Default `true`
-	SetVisible bool `json:"setVisible"`
+	SetVisible *bool `json:"setVisible,omitempty"`
 
 	// Name of the source to be added
 	SourceName string `json:"sourceName,omitempty"`

--- a/api/requests/scene_items/xx_generated.getsceneitemproperties.go
+++ b/api/requests/scene_items/xx_generated.getsceneitemproperties.go
@@ -53,10 +53,10 @@ type GetSceneItemPropertiesResponse struct {
 	ItemId int `json:"itemId,omitempty"`
 
 	// If the source's transform is locked.
-	Locked bool `json:"locked"`
+	Locked *bool `json:"locked,omitempty"`
 
 	// If the source is muted.
-	Muted bool `json:"muted"`
+	Muted *bool `json:"muted,omitempty"`
 
 	// Scene Item name.
 	Name string `json:"name,omitempty"`
@@ -80,7 +80,7 @@ type GetSceneItemPropertiesResponse struct {
 	SourceWidth int `json:"sourceWidth,omitempty"`
 
 	// If the source is visible.
-	Visible bool `json:"visible"`
+	Visible *bool `json:"visible,omitempty"`
 
 	// Scene item width (base source width multiplied by the horizontal scaling factor)
 	Width float64 `json:"width,omitempty"`

--- a/api/requests/scene_items/xx_generated.setsceneitemproperties.go
+++ b/api/requests/scene_items/xx_generated.setsceneitemproperties.go
@@ -26,7 +26,7 @@ type SetSceneItemPropertiesParams struct {
 	Item *typedefs.Item `json:"item,omitempty"`
 
 	// The new locked status of the source. 'true' keeps it in its current position, 'false' allows movement.
-	Locked bool `json:"locked"`
+	Locked *bool `json:"locked,omitempty"`
 
 	// The position of the object (source, scene item, etc).
 	Position *typedefs.Position `json:"position,omitempty"`
@@ -41,7 +41,7 @@ type SetSceneItemPropertiesParams struct {
 	SceneName string `json:"scene-name,omitempty"`
 
 	// The new visibility of the source. 'true' shows source, 'false' hides source.
-	Visible bool `json:"visible"`
+	Visible *bool `json:"visible,omitempty"`
 }
 
 // GetSelfName just returns "SetSceneItemProperties".

--- a/api/requests/scene_items/xx_generated.setsceneitemrender.go
+++ b/api/requests/scene_items/xx_generated.setsceneitemrender.go
@@ -16,7 +16,7 @@ type SetSceneItemRenderParams struct {
 	Item int `json:"item,omitempty"`
 
 	// true = shown ; false = hidden
-	Render bool `json:"render"`
+	Render *bool `json:"render,omitempty"`
 
 	// Name of the scene the scene item belongs to. Defaults to the currently active scene.
 	SceneName string `json:"scene-name,omitempty"`

--- a/api/requests/sources/xx_generated.createsource.go
+++ b/api/requests/sources/xx_generated.createsource.go
@@ -16,7 +16,7 @@ type CreateSourceParams struct {
 	SceneName string `json:"sceneName,omitempty"`
 
 	// Set the created SceneItem as visible or not. Defaults to true
-	SetVisible bool `json:"setVisible"`
+	SetVisible *bool `json:"setVisible,omitempty"`
 
 	// Source kind, Eg. `vlc_source`.
 	SourceKind string `json:"sourceKind,omitempty"`

--- a/api/requests/sources/xx_generated.getaudioactive.go
+++ b/api/requests/sources/xx_generated.getaudioactive.go
@@ -30,7 +30,7 @@ type GetAudioActiveResponse struct {
 	requests.ResponseBasic
 
 	// Audio active status of the source.
-	AudioActive bool `json:"audioActive"`
+	AudioActive *bool `json:"audioActive,omitempty"`
 }
 
 // GetAudioActive sends the corresponding request to the connected OBS WebSockets server.

--- a/api/requests/sources/xx_generated.getmute.go
+++ b/api/requests/sources/xx_generated.getmute.go
@@ -30,7 +30,7 @@ type GetMuteResponse struct {
 	requests.ResponseBasic
 
 	// Mute status of the source.
-	Muted bool `json:"muted"`
+	Muted *bool `json:"muted,omitempty"`
 
 	// Source name.
 	Name string `json:"name,omitempty"`

--- a/api/requests/sources/xx_generated.getsourceactive.go
+++ b/api/requests/sources/xx_generated.getsourceactive.go
@@ -30,7 +30,7 @@ type GetSourceActiveResponse struct {
 	requests.ResponseBasic
 
 	// Source active status of the source.
-	SourceActive bool `json:"sourceActive"`
+	SourceActive *bool `json:"sourceActive,omitempty"`
 }
 
 // GetSourceActive sends the corresponding request to the connected OBS WebSockets server.

--- a/api/requests/sources/xx_generated.getsourcefilterinfo.go
+++ b/api/requests/sources/xx_generated.getsourcefilterinfo.go
@@ -33,7 +33,7 @@ type GetSourceFilterInfoResponse struct {
 	requests.ResponseBasic
 
 	// Filter status (enabled or not)
-	Enabled bool `json:"enabled"`
+	Enabled *bool `json:"enabled,omitempty"`
 
 	// Filter name
 	Name string `json:"name,omitempty"`

--- a/api/requests/sources/xx_generated.getsourcetypeslist.go
+++ b/api/requests/sources/xx_generated.getsourcetypeslist.go
@@ -31,25 +31,25 @@ type GetSourceTypesListResponse struct {
 
 type Caps struct {
 	// True if interaction with this sources of this type is possible
-	CanInteract bool `json:"canInteract"`
+	CanInteract *bool `json:"canInteract,omitempty"`
 
 	// True if sources of this type should not be fully duplicated
-	DoNotDuplicate bool `json:"doNotDuplicate"`
+	DoNotDuplicate *bool `json:"doNotDuplicate,omitempty"`
 
 	// True if sources of this type may cause a feedback loop if it's audio is monitored and shouldn't be
-	DoNotSelfMonitor bool `json:"doNotSelfMonitor"`
+	DoNotSelfMonitor *bool `json:"doNotSelfMonitor,omitempty"`
 
 	// True if sources of this type provide audio
-	HasAudio bool `json:"hasAudio"`
+	HasAudio *bool `json:"hasAudio,omitempty"`
 
 	// True if sources of this type provide video
-	HasVideo bool `json:"hasVideo"`
+	HasVideo *bool `json:"hasVideo,omitempty"`
 
 	// True if source of this type provide frames asynchronously
-	IsAsync bool `json:"isAsync"`
+	IsAsync *bool `json:"isAsync,omitempty"`
 
 	// True if sources of this type composite one or more sub-sources
-	IsComposite bool `json:"isComposite"`
+	IsComposite *bool `json:"isComposite,omitempty"`
 }
 
 type Type struct {

--- a/api/requests/sources/xx_generated.gettextfreetype2properties.go
+++ b/api/requests/sources/xx_generated.gettextfreetype2properties.go
@@ -42,19 +42,19 @@ type GetTextFreetype2PropertiesResponse struct {
 	CustomWidth int `json:"custom_width,omitempty"`
 
 	// Drop shadow.
-	DropShadow bool `json:"drop_shadow"`
+	DropShadow *bool `json:"drop_shadow,omitempty"`
 
 	// The font specification for this object.
 	Font *typedefs.Font `json:"font,omitempty"`
 
 	// Read text from the specified file.
-	FromFile bool `json:"from_file"`
+	FromFile *bool `json:"from_file,omitempty"`
 
 	// Chat log.
-	LogMode bool `json:"log_mode"`
+	LogMode *bool `json:"log_mode,omitempty"`
 
 	// Outline.
-	Outline bool `json:"outline"`
+	Outline *bool `json:"outline,omitempty"`
 
 	// Source name
 	Source string `json:"source,omitempty"`
@@ -66,7 +66,7 @@ type GetTextFreetype2PropertiesResponse struct {
 	TextFile string `json:"text_file,omitempty"`
 
 	// Word wrap.
-	WordWrap bool `json:"word_wrap"`
+	WordWrap *bool `json:"word_wrap,omitempty"`
 }
 
 // GetTextFreetype2Properties sends the corresponding request to the connected OBS WebSockets server.

--- a/api/requests/sources/xx_generated.gettextgdiplusproperties.go
+++ b/api/requests/sources/xx_generated.gettextgdiplusproperties.go
@@ -42,7 +42,7 @@ type GetTextGDIPlusPropertiesResponse struct {
 	BkOpacity int `json:"bk_opacity,omitempty"`
 
 	// Chat log.
-	Chatlog bool `json:"chatlog"`
+	Chatlog *bool `json:"chatlog,omitempty"`
 
 	// Chat log lines.
 	ChatlogLines int `json:"chatlog_lines,omitempty"`
@@ -51,7 +51,7 @@ type GetTextGDIPlusPropertiesResponse struct {
 	Color int `json:"color,omitempty"`
 
 	// Extents wrap.
-	Extents bool `json:"extents"`
+	Extents *bool `json:"extents,omitempty"`
 
 	// Extents cx.
 	ExtentsCx int `json:"extents_cx,omitempty"`
@@ -66,7 +66,7 @@ type GetTextGDIPlusPropertiesResponse struct {
 	Font *typedefs.Font `json:"font,omitempty"`
 
 	// Gradient enabled.
-	Gradient bool `json:"gradient"`
+	Gradient *bool `json:"gradient,omitempty"`
 
 	// Gradient color.
 	GradientColor int `json:"gradient_color,omitempty"`
@@ -78,7 +78,7 @@ type GetTextGDIPlusPropertiesResponse struct {
 	GradientOpacity int `json:"gradient_opacity,omitempty"`
 
 	// Outline.
-	Outline bool `json:"outline"`
+	Outline *bool `json:"outline,omitempty"`
 
 	// Outline color.
 	OutlineColor int `json:"outline_color,omitempty"`
@@ -90,7 +90,7 @@ type GetTextGDIPlusPropertiesResponse struct {
 	OutlineSize int `json:"outline_size,omitempty"`
 
 	// Read text from the specified file.
-	ReadFromFile bool `json:"read_from_file"`
+	ReadFromFile *bool `json:"read_from_file,omitempty"`
 
 	// Source name.
 	Source string `json:"source,omitempty"`
@@ -102,7 +102,7 @@ type GetTextGDIPlusPropertiesResponse struct {
 	Valign string `json:"valign,omitempty"`
 
 	// Vertical text enabled.
-	Vertical bool `json:"vertical"`
+	Vertical *bool `json:"vertical,omitempty"`
 }
 
 // GetTextGDIPlusProperties sends the corresponding request to the connected OBS WebSockets server.

--- a/api/requests/sources/xx_generated.gettracks.go
+++ b/api/requests/sources/xx_generated.gettracks.go
@@ -29,17 +29,17 @@ Since v4.9.1.
 type GetTracksResponse struct {
 	requests.ResponseBasic
 
-	Track1 bool `json:"track1"`
+	Track1 *bool `json:"track1,omitempty"`
 
-	Track2 bool `json:"track2"`
+	Track2 *bool `json:"track2,omitempty"`
 
-	Track3 bool `json:"track3"`
+	Track3 *bool `json:"track3,omitempty"`
 
-	Track4 bool `json:"track4"`
+	Track4 *bool `json:"track4,omitempty"`
 
-	Track5 bool `json:"track5"`
+	Track5 *bool `json:"track5,omitempty"`
 
-	Track6 bool `json:"track6"`
+	Track6 *bool `json:"track6,omitempty"`
 }
 
 // GetTracks sends the corresponding request to the connected OBS WebSockets server.

--- a/api/requests/sources/xx_generated.getvolume.go
+++ b/api/requests/sources/xx_generated.getvolume.go
@@ -16,7 +16,7 @@ type GetVolumeParams struct {
 	Source string `json:"source,omitempty"`
 
 	// Output volume in decibels of attenuation instead of amplitude/mul.
-	UseDecibel bool `json:"useDecibel"`
+	UseDecibel *bool `json:"useDecibel,omitempty"`
 }
 
 // GetSelfName just returns "GetVolume".
@@ -33,7 +33,7 @@ type GetVolumeResponse struct {
 	requests.ResponseBasic
 
 	// Indicates whether the source is muted.
-	Muted bool `json:"muted"`
+	Muted *bool `json:"muted,omitempty"`
 
 	// Source name.
 	Name string `json:"name,omitempty"`

--- a/api/requests/sources/xx_generated.setmute.go
+++ b/api/requests/sources/xx_generated.setmute.go
@@ -13,7 +13,7 @@ type SetMuteParams struct {
 	requests.ParamsBasic
 
 	// Desired mute status.
-	Mute bool `json:"mute"`
+	Mute *bool `json:"mute,omitempty"`
 
 	// Source name.
 	Source string `json:"source,omitempty"`

--- a/api/requests/sources/xx_generated.setsourcefiltervisibility.go
+++ b/api/requests/sources/xx_generated.setsourcefiltervisibility.go
@@ -13,7 +13,7 @@ type SetSourceFilterVisibilityParams struct {
 	requests.ParamsBasic
 
 	// New filter state
-	FilterEnabled bool `json:"filterEnabled"`
+	FilterEnabled *bool `json:"filterEnabled,omitempty"`
 
 	// Source filter name
 	FilterName string `json:"filterName,omitempty"`

--- a/api/requests/sources/xx_generated.settextfreetype2properties.go
+++ b/api/requests/sources/xx_generated.settextfreetype2properties.go
@@ -25,19 +25,19 @@ type SetTextFreetype2PropertiesParams struct {
 	CustomWidth int `json:"custom_width,omitempty"`
 
 	// Drop shadow.
-	DropShadow bool `json:"drop_shadow"`
+	DropShadow *bool `json:"drop_shadow,omitempty"`
 
 	// The font specification for this object.
 	Font *typedefs.Font `json:"font,omitempty"`
 
 	// Read text from the specified file.
-	FromFile bool `json:"from_file"`
+	FromFile *bool `json:"from_file,omitempty"`
 
 	// Chat log.
-	LogMode bool `json:"log_mode"`
+	LogMode *bool `json:"log_mode,omitempty"`
 
 	// Outline.
-	Outline bool `json:"outline"`
+	Outline *bool `json:"outline,omitempty"`
 
 	// Source name.
 	Source string `json:"source,omitempty"`
@@ -49,7 +49,7 @@ type SetTextFreetype2PropertiesParams struct {
 	TextFile string `json:"text_file,omitempty"`
 
 	// Word wrap.
-	WordWrap bool `json:"word_wrap"`
+	WordWrap *bool `json:"word_wrap,omitempty"`
 }
 
 // GetSelfName just returns "SetTextFreetype2Properties".

--- a/api/requests/sources/xx_generated.settextgdiplusproperties.go
+++ b/api/requests/sources/xx_generated.settextgdiplusproperties.go
@@ -25,7 +25,7 @@ type SetTextGDIPlusPropertiesParams struct {
 	BkOpacity int `json:"bk_opacity,omitempty"`
 
 	// Chat log.
-	Chatlog bool `json:"chatlog"`
+	Chatlog *bool `json:"chatlog,omitempty"`
 
 	// Chat log lines.
 	ChatlogLines int `json:"chatlog_lines,omitempty"`
@@ -34,7 +34,7 @@ type SetTextGDIPlusPropertiesParams struct {
 	Color int `json:"color,omitempty"`
 
 	// Extents wrap.
-	Extents bool `json:"extents"`
+	Extents *bool `json:"extents,omitempty"`
 
 	// Extents cx.
 	ExtentsCx int `json:"extents_cx,omitempty"`
@@ -49,7 +49,7 @@ type SetTextGDIPlusPropertiesParams struct {
 	Font *typedefs.Font `json:"font,omitempty"`
 
 	// Gradient enabled.
-	Gradient bool `json:"gradient"`
+	Gradient *bool `json:"gradient,omitempty"`
 
 	// Gradient color.
 	GradientColor int `json:"gradient_color,omitempty"`
@@ -61,7 +61,7 @@ type SetTextGDIPlusPropertiesParams struct {
 	GradientOpacity int `json:"gradient_opacity,omitempty"`
 
 	// Outline.
-	Outline bool `json:"outline"`
+	Outline *bool `json:"outline,omitempty"`
 
 	// Outline color.
 	OutlineColor int `json:"outline_color,omitempty"`
@@ -73,10 +73,10 @@ type SetTextGDIPlusPropertiesParams struct {
 	OutlineSize int `json:"outline_size,omitempty"`
 
 	// Read text from the specified file.
-	ReadFromFile bool `json:"read_from_file"`
+	ReadFromFile *bool `json:"read_from_file,omitempty"`
 
 	// Visibility of the scene item.
-	Render bool `json:"render"`
+	Render *bool `json:"render,omitempty"`
 
 	// Name of the source.
 	Source string `json:"source,omitempty"`
@@ -88,7 +88,7 @@ type SetTextGDIPlusPropertiesParams struct {
 	Valign string `json:"valign,omitempty"`
 
 	// Vertical text enabled.
-	Vertical bool `json:"vertical"`
+	Vertical *bool `json:"vertical,omitempty"`
 }
 
 // GetSelfName just returns "SetTextGDIPlusProperties".

--- a/api/requests/sources/xx_generated.settracks.go
+++ b/api/requests/sources/xx_generated.settracks.go
@@ -13,7 +13,7 @@ type SetTracksParams struct {
 	requests.ParamsBasic
 
 	// Whether audio track is active or not.
-	Active bool `json:"active"`
+	Active *bool `json:"active,omitempty"`
 
 	// Source name.
 	SourceName string `json:"sourceName,omitempty"`

--- a/api/requests/sources/xx_generated.setvolume.go
+++ b/api/requests/sources/xx_generated.setvolume.go
@@ -16,7 +16,7 @@ type SetVolumeParams struct {
 	Source string `json:"source,omitempty"`
 
 	// Interperet `volume` data as decibels instead of amplitude/mul.
-	UseDecibel bool `json:"useDecibel"`
+	UseDecibel *bool `json:"useDecibel,omitempty"`
 
 	// Desired volume. Must be between `0.0` and `20.0` for mul, and under 26.0 for dB. OBS will interpret dB values
 	// under -100.0 as Inf. Note: The OBS volume sliders only reach a maximum of 1.0mul/0.0dB, however OBS actually

--- a/api/requests/streaming/xx_generated.getstreamingstatus.go
+++ b/api/requests/streaming/xx_generated.getstreamingstatus.go
@@ -27,25 +27,25 @@ type GetStreamingStatusResponse struct {
 	requests.ResponseBasic
 
 	// Always false. Retrocompatibility with OBSRemote.
-	PreviewOnly bool `json:"preview-only"`
+	PreviewOnly *bool `json:"preview-only,omitempty"`
 
 	// Time elapsed since recording started (only present if currently recording).
 	RecTimecode string `json:"rec-timecode,omitempty"`
 
 	// Current recording status.
-	Recording bool `json:"recording"`
+	Recording *bool `json:"recording,omitempty"`
 
 	// If recording is paused.
-	RecordingPaused bool `json:"recording-paused"`
+	RecordingPaused *bool `json:"recording-paused,omitempty"`
 
 	// Time elapsed since streaming started (only present if currently streaming).
 	StreamTimecode string `json:"stream-timecode,omitempty"`
 
 	// Current streaming status.
-	Streaming bool `json:"streaming"`
+	Streaming *bool `json:"streaming,omitempty"`
 
 	// Current virtual cam status.
-	Virtualcam bool `json:"virtualcam"`
+	Virtualcam *bool `json:"virtualcam,omitempty"`
 
 	// Time elapsed since virtual cam started (only present if virtual cam currently active).
 	VirtualcamTimecode string `json:"virtualcam-timecode,omitempty"`

--- a/api/requests/streaming/xx_generated.setstreamsettings.go
+++ b/api/requests/streaming/xx_generated.setstreamsettings.go
@@ -16,7 +16,7 @@ type SetStreamSettingsParams struct {
 	requests.ParamsBasic
 
 	// Persist the settings to disk.
-	Save bool `json:"save"`
+	Save *bool `json:"save,omitempty"`
 
 	//
 	Settings *typedefs.StreamSettings `json:"settings,omitempty"`

--- a/api/requests/studio_mode/xx_generated.getstudiomodestatus.go
+++ b/api/requests/studio_mode/xx_generated.getstudiomodestatus.go
@@ -27,7 +27,7 @@ type GetStudioModeStatusResponse struct {
 	requests.ResponseBasic
 
 	// Indicates if Studio Mode is enabled.
-	StudioMode bool `json:"studio-mode"`
+	StudioMode *bool `json:"studio-mode,omitempty"`
 }
 
 // GetStudioModeStatus sends the corresponding request to the connected OBS WebSockets server. Note the variadic

--- a/api/requests/transitions/xx_generated.settbarposition.go
+++ b/api/requests/transitions/xx_generated.settbarposition.go
@@ -20,7 +20,7 @@ type SetTBarPositionParams struct {
 	// Whether or not the T-Bar gets released automatically after setting its new position (like a user releasing their
 	// mouse button after moving the T-Bar). Call `ReleaseTBar` manually if you set `release` to false. Defaults to
 	// true.
-	Release bool `json:"release"`
+	Release *bool `json:"release,omitempty"`
 }
 
 // GetSelfName just returns "SetTBarPosition".

--- a/api/requests/virtual_cam/xx_generated.getvirtualcamstatus.go
+++ b/api/requests/virtual_cam/xx_generated.getvirtualcamstatus.go
@@ -27,7 +27,7 @@ type GetVirtualCamStatusResponse struct {
 	requests.ResponseBasic
 
 	// Current virtual camera status.
-	IsVirtualCam bool `json:"isVirtualCam"`
+	IsVirtualCam *bool `json:"isVirtualCam,omitempty"`
 
 	// Time elapsed since virtual cam started (only present if virtual cam currently active).
 	VirtualCamTimecode string `json:"virtualCamTimecode,omitempty"`

--- a/api/typedefs/xx_generated.output.go
+++ b/api/typedefs/xx_generated.output.go
@@ -5,7 +5,7 @@ package typedefs
 // Output represents the complex type for Output.
 type Output struct {
 	// Output status (active or not)
-	Active bool `json:"active"`
+	Active *bool `json:"active,omitempty"`
 
 	// Output congestion
 	Congestion float64 `json:"congestion,omitempty"`
@@ -22,7 +22,7 @@ type Output struct {
 	Name string `json:"name,omitempty"`
 
 	// Output reconnection status (reconnecting or not)
-	Reconnecting bool `json:"reconnecting"`
+	Reconnecting *bool `json:"reconnecting,omitempty"`
 
 	// Output settings
 	Settings map[string]interface{} `json:"settings,omitempty"`
@@ -42,20 +42,20 @@ type Output struct {
 
 type Flags struct {
 	// Output uses audio
-	Audio bool `json:"audio"`
+	Audio *bool `json:"audio,omitempty"`
 
 	// Output is encoded
-	Encoded bool `json:"encoded"`
+	Encoded *bool `json:"encoded,omitempty"`
 
 	// Output uses several audio tracks
-	MultiTrack bool `json:"multiTrack"`
+	MultiTrack *bool `json:"multiTrack,omitempty"`
 
 	// Raw flags value
 	RawValue int `json:"rawValue,omitempty"`
 
 	// Output uses a service
-	Service bool `json:"service"`
+	Service *bool `json:"service,omitempty"`
 
 	// Output uses video
-	Video bool `json:"video"`
+	Video *bool `json:"video,omitempty"`
 }

--- a/api/typedefs/xx_generated.sceneitem.go
+++ b/api/typedefs/xx_generated.sceneitem.go
@@ -19,10 +19,10 @@ type SceneItem struct {
 	Id int `json:"id,omitempty"`
 
 	// Whether or not this Scene Item is locked and can't be moved around
-	Locked bool `json:"locked"`
+	Locked *bool `json:"locked,omitempty"`
 
 	// Whether or not this Scene Item is muted.
-	Muted bool `json:"muted"`
+	Muted *bool `json:"muted,omitempty"`
 
 	// The name of this Scene Item.
 	Name string `json:"name,omitempty"`
@@ -31,7 +31,7 @@ type SceneItem struct {
 	ParentGroupName string `json:"parentGroupName,omitempty"`
 
 	// Whether or not this Scene Item is set to "visible".
-	Render bool `json:"render"`
+	Render *bool `json:"render,omitempty"`
 
 	SourceCx float64 `json:"source_cx,omitempty"`
 

--- a/api/typedefs/xx_generated.sceneitemtransform.go
+++ b/api/typedefs/xx_generated.sceneitemtransform.go
@@ -17,7 +17,7 @@ type SceneItemTransform struct {
 	Height float64 `json:"height,omitempty"`
 
 	// If the scene item is locked in position.
-	Locked bool `json:"locked"`
+	Locked *bool `json:"locked,omitempty"`
 
 	// Name of the item's parent (if this item belongs to a group)
 	ParentGroupName string `json:"parentGroupName,omitempty"`
@@ -38,7 +38,7 @@ type SceneItemTransform struct {
 	SourceWidth int `json:"sourceWidth,omitempty"`
 
 	// If the scene item is visible.
-	Visible bool `json:"visible"`
+	Visible *bool `json:"visible,omitempty"`
 
 	// Scene item width (base source width multiplied by the horizontal scaling factor)
 	Width float64 `json:"width,omitempty"`

--- a/client.go
+++ b/client.go
@@ -192,7 +192,7 @@ func (c *Client) authenticate() error {
 		return fmt.Errorf("Failed getting auth required: %s", err)
 	}
 
-	if !authReqResp.AuthRequired {
+	if !*authReqResp.AuthRequired {
 		return nil
 	}
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -70,14 +70,14 @@ func Test_goobs_e2e(t *testing.T) {
 			SourceName: sourceName,
 			SourceKind: "text_ft2_source_v2",
 			SceneName:  sceneName,
-			SetVisible: false,
+			SetVisible: &[]bool{false}[0],
 		})
 		assert.NoError(t, err)
 		_, err = client.Sources.CreateSource(&sources.CreateSourceParams{
 			SourceName: sourceName,
 			SourceKind: "text_ft2_source_v2",
 			SceneName:  sceneName,
-			SetVisible: false,
+			SetVisible: &[]bool{false}[0],
 		})
 		assert.Error(t, err)
 

--- a/internal/comments/generate.go
+++ b/internal/comments/generate.go
@@ -276,7 +276,6 @@ func generateStructFromParams(origin string, s *Statement, name string, params [
 
 		noJSONTag := false
 		embedded := false
-		omitEmpty := true
 
 		var fieldType *Statement
 		switch val := noOptional.ReplaceAllString(field.Type, ""); val {
@@ -307,8 +306,7 @@ func generateStructFromParams(origin string, s *Statement, name string, params [
 		case "boolean":
 			fallthrough
 		case "Boolean":
-			fieldType = Bool()
-			omitEmpty = false
+			fieldType = Op("*").Bool()
 		// funkier types
 		case "Object":
 			fieldType = Map(String()).Interface()
@@ -364,7 +362,7 @@ func generateStructFromParams(origin string, s *Statement, name string, params [
 			Comment:   field.Description,
 			NoJSONTag: noJSONTag,
 			Embedded:  embedded,
-			OmitEmpty: omitEmpty,
+			OmitEmpty: true,
 		}
 	}
 


### PR DESCRIPTION
We need to be able to tell the difference between a false value, and an
unset value. Even though this change might make the UX kinda ugly if one
were to set the bools directly (e.g. `&[]bool{true}[0]`), it does make
the library more robust against future changes to the protocol.