### PR TITLE
Fix panic on connection close

### DIFF
--- a/client.go
+++ b/client.go
@@ -226,8 +226,14 @@ func (c *Client) handleConnection(messages chan json.RawMessage, errors chan err
 	for {
 		msg := json.RawMessage{}
 		if err := c.Conn.ReadJSON(&msg); err != nil {
-			errors <- fmt.Errorf("Couldn't read JSON from websocket connection: %s", err)
-			continue
+			switch err.(type) {
+			case *websocket.CloseError:
+				errors <- fmt.Errorf("Websocket connection closed: %s", err)
+				return
+			default:
+				errors <- fmt.Errorf("Couldn't read JSON from websocket connection: %s", err)
+				continue
+			}
 		}
 
 		messages <- msg


### PR DESCRIPTION
When the connection is closed from OBS side `handleConnection()` needs to stop trying to call `ReadJSON()`. Otherwise the underlying websocket package panics with `panic: repeated read on failed websocket connection`.

I'm not completely sure if this is the right approach to handle this issue. It works pretty well for me by listening to errors and recreating the goobs instance in this case.