### PR TITLE
client: error out when authentication failed

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -39,6 +39,7 @@ main() {
         # note: `scenes` and `transitions` must be ran after `ui`
         #
         categories='
+		client
 		config
 		filters
 		general

--- a/zz_generated._test.go
+++ b/zz_generated._test.go
@@ -23,8 +23,20 @@ import (
 	transitions "github.com/andreykaipov/goobs/api/requests/transitions"
 	ui "github.com/andreykaipov/goobs/api/requests/ui"
 	typedefs "github.com/andreykaipov/goobs/api/typedefs"
+	websocket "github.com/gorilla/websocket"
 	assert "github.com/stretchr/testify/assert"
 )
+
+func Test_client(t *testing.T) {
+	_, err := goobs.New(
+		"localhost:"+os.Getenv("OBS_PORT"),
+		goobs.WithPassword("wrongpassword"),
+		goobs.WithRequestHeader(http.Header{"User-Agent": []string{"goobs-e2e/0.0.0"}}),
+	)
+	assert.Error(t, err)
+	assert.IsType(t, &websocket.CloseError{}, err)
+	assert.Equal(t, err.(*websocket.CloseError).Code, 4009)
+}
 
 func Test_config(t *testing.T) {
 	client, err := goobs.New(


### PR DESCRIPTION
When wrong password was specified, `goobs.New()` didn't return.