### PR TITLE
client: close protocol version check connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -181,6 +181,7 @@ func (c *Client) checkProtocolVersion() error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 
 	_ = conn.WriteMessage(
 		websocket.TextMessage,


### PR DESCRIPTION
This change is not important. Just a small improvement.

I noticed that obs-websocket server closes the version check connection [5 seconds after version check](https://obsproject.com/logs/WqaE0o11v0W23Flw). Probably according to the value of `timeout_close_handshake` from [websocketpp](https://docs.websocketpp.org/reference_8config.html).

After this change, version check connection [closes immediately](https://obsproject.com/logs/REiWYw7pBgjqyRkJ).