### PR TITLE
obs websocket v5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [protocol-url]: https://github.com/obsproject/obs-websocket/blob/5.0.2/docs/generated/protocol.md
 [doc-img]: https://img.shields.io/badge/pkg.go.dev-reference-blue?logo=go&logoColor=white&style=flat-square
 [doc-url]: https://pkg.go.dev/github.com/andreykaipov/goobs
-[build-img]: https://img.shields.io/github/workflow/status/andreykaipov/goobs/test?logo=github&style=flat-square
+[build-img]: https://img.shields.io/github/actions/workflow/status/andreykaipov/goobs/ci.yml?logo=github&style=flat-square&branch=master
 [build-url]: https://github.com/andreykaipov/goobs/actions/workflows/ci.yml
 [goreport-img]: https://goreportcard.com/badge/github.com/andreykaipov/goobs?logo=go&logoColor=white&style=flat-square
 [goreport-url]: https://goreportcard.com/report/github.com/andreykaipov/goobs

--- a/api/events/xx_generated.general.customevent.go
+++ b/api/events/xx_generated.general.customevent.go
@@ -1,0 +1,13 @@
+// This file has been automatically generated. Don't edit it.
+
+package events
+
+/*
+Represents the event body for the CustomEvent event.
+
+Custom event emitted by `BroadcastCustomEvent`.
+*/
+type CustomEvent struct {
+	// Custom event data
+	EventData interface{} `json:"eventData,omitempty"`
+}

--- a/api/events/xx_generated.inputs.inputvolumechanged.go
+++ b/api/events/xx_generated.inputs.inputvolumechanged.go
@@ -14,6 +14,6 @@ type InputVolumeChanged struct {
 	// New volume level in dB
 	InputVolumeDb float64 `json:"inputVolumeDb,omitempty"`
 
-	// New volume level in multimap
+	// New volume level multiplier
 	InputVolumeMul float64 `json:"inputVolumeMul,omitempty"`
 }

--- a/api/events/xx_generated.ui.screenshotsaved.go
+++ b/api/events/xx_generated.ui.screenshotsaved.go
@@ -1,0 +1,17 @@
+// This file has been automatically generated. Don't edit it.
+
+package events
+
+/*
+Represents the event body for the ScreenshotSaved event.
+
+A screenshot has been saved.
+
+Note: Triggered for the screenshot feature available in `Settings -> Hotkeys -> Screenshot Output` ONLY.
+Applications using `Get/SaveSourceScreenshot` should implement a `CustomEvent` if this kind of inter-client
+communication is desired.
+*/
+type ScreenshotSaved struct {
+	// Path of the saved image file
+	SavedScreenshotPath string `json:"savedScreenshotPath,omitempty"`
+}

--- a/api/events/zz_generated.events.go
+++ b/api/events/zz_generated.events.go
@@ -106,8 +106,12 @@ func GetType(name string) interface{} {
 		return &SceneTransitionVideoEnded{}
 	case "StudioModeStateChanged":
 		return &StudioModeStateChanged{}
+	case "ScreenshotSaved":
+		return &ScreenshotSaved{}
 	case "VendorEvent":
 		return &VendorEvent{}
+	case "CustomEvent":
+		return &CustomEvent{}
 	default:
 		return nil
 	}

--- a/api/requests/general/xx_generated.sleep.go
+++ b/api/requests/general/xx_generated.sleep.go
@@ -21,7 +21,11 @@ type SleepResponse struct{}
 
 // Sleeps for a time duration or number of frames. Only available in request batches with types `SERIAL_REALTIME` or
 // `SERIAL_FRAME`.
-func (c *Client) Sleep(params *SleepParams) (*SleepResponse, error) {
+func (c *Client) Sleep(paramss ...*SleepParams) (*SleepResponse, error) {
+	if len(paramss) == 0 {
+		paramss = []*SleepParams{{}}
+	}
+	params := paramss[0]
 	data := &SleepResponse{}
 	return data, c.SendRequest(params, data)
 }

--- a/api/requests/inputs/xx_generated.pressinputpropertiesbutton.go
+++ b/api/requests/inputs/xx_generated.pressinputpropertiesbutton.go
@@ -22,6 +22,10 @@ type PressInputPropertiesButtonResponse struct{}
 /*
 Presses a button in the properties of an input.
 
+Some known `propertyName` values are:
+
+- `refreshnocache` - Browser source reload button
+
 Note: Use this in cases where there is a button in the properties of an input that cannot be accessed in any other way. For example, browser sources, where there is a refresh button.
 */
 func (c *Client) PressInputPropertiesButton(

--- a/api/requests/outputs/xx_generated.getoutputlist.go
+++ b/api/requests/outputs/xx_generated.getoutputlist.go
@@ -11,7 +11,10 @@ func (o *GetOutputListParams) GetRequestName() string {
 }
 
 // Represents the response body for the GetOutputList request.
-type GetOutputListResponse struct{}
+type GetOutputListResponse struct {
+	// Array of outputs
+	Outputs []interface{} `json:"outputs,omitempty"`
+}
 
 // Gets the list of available outputs.
 func (c *Client) GetOutputList(paramss ...*GetOutputListParams) (*GetOutputListResponse, error) {

--- a/api/requests/record/xx_generated.getrecordstatus.go
+++ b/api/requests/record/xx_generated.getrecordstatus.go
@@ -12,9 +12,6 @@ func (o *GetRecordStatusParams) GetRequestName() string {
 
 // Represents the response body for the GetRecordStatus request.
 type GetRecordStatusResponse struct {
-	// Whether the output is paused
-	OuputPaused bool `json:"ouputPaused,omitempty"`
-
 	// Whether the output is active
 	OutputActive bool `json:"outputActive,omitempty"`
 
@@ -23,6 +20,9 @@ type GetRecordStatusResponse struct {
 
 	// Current duration in milliseconds for the output
 	OutputDuration float64 `json:"outputDuration,omitempty"`
+
+	// Whether the output is paused
+	OutputPaused bool `json:"outputPaused,omitempty"`
 
 	// Current formatted timecode string for the output
 	OutputTimecode string `json:"outputTimecode,omitempty"`

--- a/api/requests/sceneitems/xx_generated.getgroupsceneitemlist.go
+++ b/api/requests/sceneitems/xx_generated.getgroupsceneitemlist.go
@@ -23,7 +23,7 @@ type GetGroupSceneItemListResponse struct {
 /*
 Basically GetSceneItemList, but for groups.
 
-Using groups at all in OBS is discouraged, as they are very broken under the hood.
+Using groups at all in OBS is discouraged, as they are very broken under the hood. Please use nested scenes instead.
 
 Groups only
 */

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package goobs
 
 const (
 	goobs_version                  = "0.11.0"
-	obs_websocket_protocol_version = "5.0.2"
+	obs_websocket_protocol_version = "5.1.0"
 )

--- a/version.go
+++ b/version.go
@@ -1,6 +1,6 @@
 package goobs
 
 const (
-	goobs_version                  = "0.11.0"
+	goobs_version                  = "0.12.0"
 	obs_websocket_protocol_version = "5.1.0"
 )


### PR DESCRIPTION
Guess there's no new stuff. Surprised there's no breaking changes!

For posterity, release process was as follows:

1. Bump `goobs_version` and `obs_protocol_version` in `version.go`
2. Run `make clean && make generate` to pull in latest protocol changes
3. Ensure no tests are failing via `make test`, modifying `internal/generate/tests/main.go` if necessary
4. Double check the versions from step 1, and merge the PR in
5. Back on the main branch, pull in the latest changes and run `make release`
6. View and edit the release from the Web UI if necessary (I like to add the corresponding `obs-websocket` protocol version to the name of the release)