### PR TITLE
Use `time.NewTimer()` instead of `time.After()`

### DIFF
--- a/client.go
+++ b/client.go
@@ -172,10 +172,14 @@ func (c *Client) connect() (err error) {
 	go c.handleRawServerMessages(authComplete)
 	go c.handleOpcodes(authComplete)
 
+	timeout, timer := newTimeoutTimer(c.ResponseTimeout * time.Millisecond)
 	select {
 	case a := <-authComplete:
+		if timer != nil {
+			timer.Stop()
+		}
 		return a
-	case <-time.After(c.ResponseTimeout * time.Millisecond):
+	case <-timeout:
 		return fmt.Errorf("timeout waiting for authentication: %dms", c.ResponseTimeout)
 	}
 }
@@ -355,7 +359,7 @@ func (c *Client) writeEvent(event interface{}) {
 			// incoming events was full (but might not be by now),
 			// so safely read off the oldest, and write the latest
 			select {
-			case _ = <-c.IncomingEvents:
+			case <-c.IncomingEvents:
 			default:
 			}
 
@@ -368,4 +372,16 @@ func (c *Client) Listen(f func(interface{})) {
 	for event := range c.IncomingEvents {
 		f(event)
 	}
+}
+
+// newTimeoutTimer is an alternative to time.After with the possibility to cancel
+// the underlying time.Timer to achieve better efficiency.
+// time.Duration d <= 0 means no timeout or waiting forever.
+// See https://pkg.go.dev/time#After
+func newTimeoutTimer(d time.Duration) (timeout <-chan time.Time, timer *time.Timer) {
+	if d > 0 {
+		timer = time.NewTimer(d)
+		timeout = timer.C
+	}
+	return
 }


### PR DESCRIPTION
For efficiency, cancel time.Timer after no longer needed. See https://pkg.go.dev/time#After

Note on behavior change:
timeout duration <= 0 now means waiting forever instead of immediately times out..