### PR TITLE
Update client.go

### DIFF
--- a/client.go
+++ b/client.go
@@ -251,7 +251,7 @@ func (c *Client) handleRawServerMessages(auth chan<- error) {
 				return
 			default:
 				c.errors <- fmt.Errorf("reading raw message from websocket connection: %w", t)
-				continue
+				return
 			}
 		}
 


### PR DESCRIPTION
whenever there is an error technically need to return, if we don't can get caught in a loop and have gorilla WebSockets library panic.