### PR TITLE
client: handle disconnections better

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Websocket server version: 5.1.0
 
 ## advanced configuration
 
-- `GOOBS_LOG` can be set to `debug`, `info`, or `error` to better understand what our client is doing under the hood.
+- `GOOBS_LOG` can be set to `trace`, `debug`, `info`, or `error` to better understand what our client is doing under the hood.
 
 - `GOOBS_PROFILE` can be set to enable profiling.
   For example, the following will help us find unreleased memory:

--- a/api/client.go
+++ b/api/client.go
@@ -56,7 +56,7 @@ func (c *Client) SendRequest(requestBody Params, responseBody interface{}) error
 	name := requestBody.GetRequestName()
 	id := uid.String()
 
-	c.Log.Printf("[INFO] Sending %s Request with ID %s", name, id)
+	c.Log.Printf("[TRACE] Sending %s Request with ID %s", name, id)
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()

--- a/client.go
+++ b/client.go
@@ -120,7 +120,7 @@ func New(host string, opts ...Option) (*Client, error) {
 			ResponseTimeout:   10000,
 			Log: log.New(
 				&logutils.LevelFilter{
-					Levels:   []logutils.LogLevel{"DEBUG", "INFO", "ERROR", ""},
+					Levels:   []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "ERROR", ""},
 					MinLevel: logutils.LogLevel(strings.ToUpper(os.Getenv("GOOBS_LOG"))),
 					Writer: api.LoggerWithWrite(func(p []byte) (int, error) {
 						return os.Stderr.WriteString(fmt.Sprintf("\033[36m%s\033[0m", p))
@@ -255,7 +255,7 @@ func (c *Client) handleRawServerMessages(auth chan<- error) {
 			}
 		}
 
-		c.Log.Printf("[DEBUG] Raw server message: %s", raw)
+		c.Log.Printf("[TRACE] Raw server message: %s", raw)
 
 		opcode, err := opcodes.ParseRawMessage(raw)
 		if err != nil {
@@ -306,8 +306,7 @@ func (c *Client) handleOpcodes(auth chan<- error) {
 			// can't imagine we need this
 
 		case *opcodes.Event:
-			c.Log.Printf("[INFO] Got %s Event", val.Type)
-			c.Log.Printf("[DEBUG] Event Data: %s", val.Data)
+			c.Log.Printf("[TRACE] Got %s event: %s", val.Type, val.Data)
 
 			event := events.GetType(val.Type)
 
@@ -328,7 +327,7 @@ func (c *Client) handleOpcodes(auth chan<- error) {
 			c.writeEvent(event)
 
 		case *opcodes.Request:
-			c.Log.Printf("[DEBUG] Got %s Request with ID %s", val.Type, val.ID)
+			c.Log.Printf("[TRACE] Got %s Request with ID %s", val.Type, val.ID)
 
 			msg := opcodes.Wrap(val).Bytes()
 			if err := c.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
@@ -336,7 +335,7 @@ func (c *Client) handleOpcodes(auth chan<- error) {
 			}
 
 		case *opcodes.RequestResponse:
-			c.Log.Printf("[INFO] Got %s Response for ID %s (%d)", val.Type, val.ID, val.Status.Code)
+			c.Log.Printf("[TRACE] Got %s Response for ID %s (%d)", val.Type, val.ID, val.Status.Code)
 
 			c.IncomingResponses <- val
 

--- a/client.go
+++ b/client.go
@@ -199,7 +199,15 @@ func (c *Client) checkProtocolVersion() error {
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer func() {
+		if err := conn.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "Protocol check"),
+		); err != nil {
+			c.Log.Printf("[ERROR] Force closing initial protocol check connection", err)
+			_ = conn.Close()
+		}
+	}()
 
 	_ = conn.WriteMessage(
 		websocket.TextMessage,

--- a/client_test.go
+++ b/client_test.go
@@ -1,11 +1,13 @@
 package goobs_test
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	goobs "github.com/andreykaipov/goobs"
 	"github.com/gorilla/websocket"
@@ -13,44 +15,67 @@ import (
 )
 
 func Test_client(t *testing.T) {
-	var err error
-	_, err = goobs.New(
-		"localhost:"+os.Getenv("OBS_PORT"),
-		goobs.WithPassword("wrongpassword"),
-		goobs.WithRequestHeader(http.Header{"User-Agent": []string{"goobs-e2e/0.0.0"}}),
-	)
-	assert.Error(t, err)
-	assert.IsType(t, &websocket.CloseError{}, err)
-	assert.Equal(t, err.(*websocket.CloseError).Code, 4009)
-	_, err = goobs.New(
-		"localhost:42069",
-		goobs.WithPassword("wrongpassword"),
-		goobs.WithRequestHeader(http.Header{"User-Agent": []string{"goobs-e2e/0.0.0"}}),
-	)
-	assert.Error(t, err)
-	assert.IsType(t, &net.OpError{}, err)
+	t.Run("wrong password", func(t *testing.T) {
+		_, err := goobs.New(
+			"localhost:"+os.Getenv("OBS_PORT"),
+			goobs.WithPassword("wrongpassword"),
+			goobs.WithRequestHeader(http.Header{"User-Agent": []string{"goobs-e2e/0.0.0"}}),
+		)
+		assert.Error(t, err)
+		assert.IsType(t, &websocket.CloseError{}, err)
+		assert.Equal(t, err.(*websocket.CloseError).Code, 4009)
+	})
+
+	t.Run("server isn't running", func(t *testing.T) {
+		_, err := goobs.New(
+			"localhost:42069",
+			goobs.WithPassword("wrongpassword"),
+			goobs.WithRequestHeader(http.Header{"User-Agent": []string{"goobs-e2e/0.0.0"}}),
+		)
+		assert.Error(t, err)
+		assert.IsType(t, &net.OpError{}, err)
+	})
+
+	t.Run("right password", func(t *testing.T) {
+		client, err := goobs.New(
+			"localhost:"+os.Getenv("OBS_PORT"),
+			goobs.WithPassword("goodpassword"),
+			goobs.WithRequestHeader(http.Header{"User-Agent": []string{"goobs-e2e/0.0.0"}}),
+		)
+		assert.NoError(t, err)
+		t.Cleanup(func() {
+			client.Disconnect()
+		})
+		time.Sleep(1 * time.Second)
+	})
 }
 
 func Test_multi_goroutine(t *testing.T) {
-	client, err := goobs.New(
-		"localhost:"+os.Getenv("OBS_PORT"),
-		goobs.WithPassword("goodpassword"),
-		goobs.WithRequestHeader(http.Header{"User-Agent": []string{"goobs-e2e/0.0.0"}}),
-	)
-	assert.NoError(t, err)
-	t.Cleanup(func() {
-		client.Disconnect()
-	})
-	wg := sync.WaitGroup{}
-	for i := 0; i < 1000; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_, err := client.Scenes.GetSceneList()
+	for i := 1; i <= 10; i++ {
+		t.Run(fmt.Sprintf("goroutine-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			client, err := goobs.New(
+				"localhost:"+os.Getenv("OBS_PORT"),
+				goobs.WithPassword("goodpassword"),
+				goobs.WithRequestHeader(http.Header{"User-Agent": []string{"goobs-e2e/0.0.0"}}),
+			)
 			assert.NoError(t, err)
-		}()
+			t.Cleanup(func() {
+				client.Disconnect()
+			})
+			wg := sync.WaitGroup{}
+			for i := 0; i < 5_000; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_, err := client.Scenes.GetSceneList()
+					assert.NoError(t, err)
+				}()
+			}
+			wg.Wait()
+		})
 	}
-	wg.Wait()
 }
 
 func Test_profile(t *testing.T) {

--- a/test.sh
+++ b/test.sh
@@ -27,7 +27,7 @@ setup() {
 
 gotest() {
         category="$1"
-        go test -v -run="^Test_$category$" -coverprofile=cover.out -coverpkg=./... -covermode=$covermode ./...
+        go test -v -run="^Test_$category$" -count 1 -coverprofile=cover.out -coverpkg=./... -covermode=$covermode ./...
         awk 'NR>1' cover.out >>coverall.out
 }
 
@@ -42,6 +42,7 @@ main() {
         categories='
                 client
                 multi_goroutine
+                profile
                 config
                 filters
                 general


### PR DESCRIPTION
In cases of highly concurrent clients, there seems to be some bugs when disconnecting and still trying to write to the closed websocket connection or to the internal channels used. These added checks should hopefully prevent most of those panics. 🤞

For some reason this was more prevalent when using gorilla/websocket v1.5.1 instead of v1.5.0 (https://github.com/andreykaipov/goobs/pull/64).

Also changes most of the DEBUG logs to TRACE logs.