### PR TITLE
don't expose ResponseCommon struct from Responses

### DIFF
--- a/api/requests/config/xx_generated.createprofile.go
+++ b/api/requests/config/xx_generated.createprofile.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the CreateProfile request.
 type CreateProfileParams struct {
 	// Name for the new profile
@@ -25,7 +23,7 @@ func (o *CreateProfileParams) GetRequestName() string {
 
 // Represents the response body for the CreateProfile request.
 type CreateProfileResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Creates a new profile, switching to it in the process

--- a/api/requests/config/xx_generated.createscenecollection.go
+++ b/api/requests/config/xx_generated.createscenecollection.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the CreateSceneCollection request.
 type CreateSceneCollectionParams struct {
 	// Name for the new scene collection
@@ -25,7 +23,7 @@ func (o *CreateSceneCollectionParams) GetRequestName() string {
 
 // Represents the response body for the CreateSceneCollection request.
 type CreateSceneCollectionResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/config/xx_generated.getpersistentdata.go
+++ b/api/requests/config/xx_generated.getpersistentdata.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetPersistentData request.
 type GetPersistentDataParams struct {
 	// The data realm to select. `OBS_WEBSOCKET_DATA_REALM_GLOBAL` or `OBS_WEBSOCKET_DATA_REALM_PROFILE`
@@ -32,7 +30,7 @@ func (o *GetPersistentDataParams) GetRequestName() string {
 
 // Represents the response body for the GetPersistentData request.
 type GetPersistentDataResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Value associated with the slot. `null` if not set
 	SlotValue any `json:"slotValue,omitempty"`

--- a/api/requests/config/xx_generated.getprofilelist.go
+++ b/api/requests/config/xx_generated.getprofilelist.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetProfileList request.
 type GetProfileListParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetProfileListParams) GetRequestName() string {
 
 // Represents the response body for the GetProfileList request.
 type GetProfileListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// The name of the current profile
 	CurrentProfileName string `json:"currentProfileName,omitempty"`

--- a/api/requests/config/xx_generated.getprofileparameter.go
+++ b/api/requests/config/xx_generated.getprofileparameter.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetProfileParameter request.
 type GetProfileParameterParams struct {
 	// Category of the parameter to get
@@ -32,7 +30,7 @@ func (o *GetProfileParameterParams) GetRequestName() string {
 
 // Represents the response body for the GetProfileParameter request.
 type GetProfileParameterResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Default value associated with the parameter. `null` if no default
 	DefaultParameterValue string `json:"defaultParameterValue,omitempty"`

--- a/api/requests/config/xx_generated.getrecorddirectory.go
+++ b/api/requests/config/xx_generated.getrecorddirectory.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetRecordDirectory request.
 type GetRecordDirectoryParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetRecordDirectoryParams) GetRequestName() string {
 
 // Represents the response body for the GetRecordDirectory request.
 type GetRecordDirectoryResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Output directory
 	RecordDirectory string `json:"recordDirectory,omitempty"`

--- a/api/requests/config/xx_generated.getscenecollectionlist.go
+++ b/api/requests/config/xx_generated.getscenecollectionlist.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetSceneCollectionList request.
 type GetSceneCollectionListParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetSceneCollectionListParams) GetRequestName() string {
 
 // Represents the response body for the GetSceneCollectionList request.
 type GetSceneCollectionListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// The name of the current scene collection
 	CurrentSceneCollectionName string `json:"currentSceneCollectionName,omitempty"`

--- a/api/requests/config/xx_generated.getstreamservicesettings.go
+++ b/api/requests/config/xx_generated.getstreamservicesettings.go
@@ -2,10 +2,7 @@
 
 package config
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the GetStreamServiceSettings request.
 type GetStreamServiceSettingsParams struct{}
@@ -17,7 +14,7 @@ func (o *GetStreamServiceSettingsParams) GetRequestName() string {
 
 // Represents the response body for the GetStreamServiceSettings request.
 type GetStreamServiceSettingsResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Stream service settings
 	StreamServiceSettings *typedefs.StreamServiceSettings `json:"streamServiceSettings,omitempty"`

--- a/api/requests/config/xx_generated.getvideosettings.go
+++ b/api/requests/config/xx_generated.getvideosettings.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetVideoSettings request.
 type GetVideoSettingsParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetVideoSettingsParams) GetRequestName() string {
 
 // Represents the response body for the GetVideoSettings request.
 type GetVideoSettingsResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Height of the base (canvas) resolution in pixels
 	BaseHeight float64 `json:"baseHeight,omitempty"`

--- a/api/requests/config/xx_generated.removeprofile.go
+++ b/api/requests/config/xx_generated.removeprofile.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the RemoveProfile request.
 type RemoveProfileParams struct {
 	// Name of the profile to remove
@@ -25,7 +23,7 @@ func (o *RemoveProfileParams) GetRequestName() string {
 
 // Represents the response body for the RemoveProfile request.
 type RemoveProfileResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Removes a profile. If the current profile is chosen, it will change to a different profile first.

--- a/api/requests/config/xx_generated.setcurrentprofile.go
+++ b/api/requests/config/xx_generated.setcurrentprofile.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetCurrentProfile request.
 type SetCurrentProfileParams struct {
 	// Name of the profile to switch to
@@ -25,7 +23,7 @@ func (o *SetCurrentProfileParams) GetRequestName() string {
 
 // Represents the response body for the SetCurrentProfile request.
 type SetCurrentProfileResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Switches to a profile.

--- a/api/requests/config/xx_generated.setcurrentscenecollection.go
+++ b/api/requests/config/xx_generated.setcurrentscenecollection.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetCurrentSceneCollection request.
 type SetCurrentSceneCollectionParams struct {
 	// Name of the scene collection to switch to
@@ -25,7 +23,7 @@ func (o *SetCurrentSceneCollectionParams) GetRequestName() string {
 
 // Represents the response body for the SetCurrentSceneCollection request.
 type SetCurrentSceneCollectionResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/config/xx_generated.setpersistentdata.go
+++ b/api/requests/config/xx_generated.setpersistentdata.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetPersistentData request.
 type SetPersistentDataParams struct {
 	// The data realm to select. `OBS_WEBSOCKET_DATA_REALM_GLOBAL` or `OBS_WEBSOCKET_DATA_REALM_PROFILE`
@@ -39,7 +37,7 @@ func (o *SetPersistentDataParams) GetRequestName() string {
 
 // Represents the response body for the SetPersistentData request.
 type SetPersistentDataResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the value of a "slot" from the selected persistent data realm.

--- a/api/requests/config/xx_generated.setprofileparameter.go
+++ b/api/requests/config/xx_generated.setprofileparameter.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetProfileParameter request.
 type SetProfileParameterParams struct {
 	// Category of the parameter to set
@@ -39,7 +37,7 @@ func (o *SetProfileParameterParams) GetRequestName() string {
 
 // Represents the response body for the SetProfileParameter request.
 type SetProfileParameterResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the value of a parameter in the current profile's configuration.

--- a/api/requests/config/xx_generated.setstreamservicesettings.go
+++ b/api/requests/config/xx_generated.setstreamservicesettings.go
@@ -2,10 +2,7 @@
 
 package config
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the SetStreamServiceSettings request.
 type SetStreamServiceSettingsParams struct {
@@ -38,7 +35,7 @@ func (o *SetStreamServiceSettingsParams) GetRequestName() string {
 
 // Represents the response body for the SetStreamServiceSettings request.
 type SetStreamServiceSettingsResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/config/xx_generated.setvideosettings.go
+++ b/api/requests/config/xx_generated.setvideosettings.go
@@ -2,8 +2,6 @@
 
 package config
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetVideoSettings request.
 type SetVideoSettingsParams struct {
 	// Height of the base (canvas) resolution in pixels
@@ -60,7 +58,7 @@ func (o *SetVideoSettingsParams) GetRequestName() string {
 
 // Represents the response body for the SetVideoSettings request.
 type SetVideoSettingsResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/config/zz_generated.client.go
+++ b/api/requests/config/zz_generated.client.go
@@ -4,6 +4,8 @@ package config
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'config' requests.
 type Client struct {
 	*api.Client

--- a/api/requests/filters/xx_generated.createsourcefilter.go
+++ b/api/requests/filters/xx_generated.createsourcefilter.go
@@ -2,8 +2,6 @@
 
 package filters
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the CreateSourceFilter request.
 type CreateSourceFilterParams struct {
 	// The kind of filter to be created
@@ -46,7 +44,7 @@ func (o *CreateSourceFilterParams) GetRequestName() string {
 
 // Represents the response body for the CreateSourceFilter request.
 type CreateSourceFilterResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Creates a new filter, adding it to the specified source.

--- a/api/requests/filters/xx_generated.getsourcefilter.go
+++ b/api/requests/filters/xx_generated.getsourcefilter.go
@@ -2,8 +2,6 @@
 
 package filters
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetSourceFilter request.
 type GetSourceFilterParams struct {
 	// Name of the filter
@@ -32,7 +30,7 @@ func (o *GetSourceFilterParams) GetRequestName() string {
 
 // Represents the response body for the GetSourceFilter request.
 type GetSourceFilterResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the filter is enabled
 	FilterEnabled bool `json:"filterEnabled,omitempty"`

--- a/api/requests/filters/xx_generated.getsourcefilterdefaultsettings.go
+++ b/api/requests/filters/xx_generated.getsourcefilterdefaultsettings.go
@@ -2,8 +2,6 @@
 
 package filters
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetSourceFilterDefaultSettings request.
 type GetSourceFilterDefaultSettingsParams struct {
 	// Filter kind to get the default settings for
@@ -25,7 +23,7 @@ func (o *GetSourceFilterDefaultSettingsParams) GetRequestName() string {
 
 // Represents the response body for the GetSourceFilterDefaultSettings request.
 type GetSourceFilterDefaultSettingsResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Object of default settings for the filter kind
 	DefaultFilterSettings map[string]any `json:"defaultFilterSettings,omitempty"`

--- a/api/requests/filters/xx_generated.getsourcefilterlist.go
+++ b/api/requests/filters/xx_generated.getsourcefilterlist.go
@@ -2,10 +2,7 @@
 
 package filters
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the GetSourceFilterList request.
 type GetSourceFilterListParams struct {
@@ -28,7 +25,7 @@ func (o *GetSourceFilterListParams) GetRequestName() string {
 
 // Represents the response body for the GetSourceFilterList request.
 type GetSourceFilterListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Array of filters
 	Filters []*typedefs.Filter `json:"filters,omitempty"`

--- a/api/requests/filters/xx_generated.removesourcefilter.go
+++ b/api/requests/filters/xx_generated.removesourcefilter.go
@@ -2,8 +2,6 @@
 
 package filters
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the RemoveSourceFilter request.
 type RemoveSourceFilterParams struct {
 	// Name of the filter to remove
@@ -32,7 +30,7 @@ func (o *RemoveSourceFilterParams) GetRequestName() string {
 
 // Represents the response body for the RemoveSourceFilter request.
 type RemoveSourceFilterResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Removes a filter from a source.

--- a/api/requests/filters/xx_generated.setsourcefilterenabled.go
+++ b/api/requests/filters/xx_generated.setsourcefilterenabled.go
@@ -2,8 +2,6 @@
 
 package filters
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetSourceFilterEnabled request.
 type SetSourceFilterEnabledParams struct {
 	// New enable state of the filter
@@ -39,7 +37,7 @@ func (o *SetSourceFilterEnabledParams) GetRequestName() string {
 
 // Represents the response body for the SetSourceFilterEnabled request.
 type SetSourceFilterEnabledResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the enable state of a source filter.

--- a/api/requests/filters/xx_generated.setsourcefilterindex.go
+++ b/api/requests/filters/xx_generated.setsourcefilterindex.go
@@ -2,8 +2,6 @@
 
 package filters
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetSourceFilterIndex request.
 type SetSourceFilterIndexParams struct {
 	// New index position of the filter
@@ -39,7 +37,7 @@ func (o *SetSourceFilterIndexParams) GetRequestName() string {
 
 // Represents the response body for the SetSourceFilterIndex request.
 type SetSourceFilterIndexResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the index position of a filter on a source.

--- a/api/requests/filters/xx_generated.setsourcefiltername.go
+++ b/api/requests/filters/xx_generated.setsourcefiltername.go
@@ -2,8 +2,6 @@
 
 package filters
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetSourceFilterName request.
 type SetSourceFilterNameParams struct {
 	// Current name of the filter
@@ -39,7 +37,7 @@ func (o *SetSourceFilterNameParams) GetRequestName() string {
 
 // Represents the response body for the SetSourceFilterName request.
 type SetSourceFilterNameResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the name of a source filter (rename).

--- a/api/requests/filters/xx_generated.setsourcefiltersettings.go
+++ b/api/requests/filters/xx_generated.setsourcefiltersettings.go
@@ -2,8 +2,6 @@
 
 package filters
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetSourceFilterSettings request.
 type SetSourceFilterSettingsParams struct {
 	// Name of the filter to set the settings of
@@ -47,7 +45,7 @@ func (o *SetSourceFilterSettingsParams) GetRequestName() string {
 
 // Represents the response body for the SetSourceFilterSettings request.
 type SetSourceFilterSettingsResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the settings of a source filter.

--- a/api/requests/filters/zz_generated.client.go
+++ b/api/requests/filters/zz_generated.client.go
@@ -4,6 +4,8 @@ package filters
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'filters' requests.
 type Client struct {
 	*api.Client

--- a/api/requests/general/xx_generated.broadcastcustomevent.go
+++ b/api/requests/general/xx_generated.broadcastcustomevent.go
@@ -2,8 +2,6 @@
 
 package general
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the BroadcastCustomEvent request.
 type BroadcastCustomEventParams struct {
 	// Data payload to emit to all receivers
@@ -25,7 +23,7 @@ func (o *BroadcastCustomEventParams) GetRequestName() string {
 
 // Represents the response body for the BroadcastCustomEvent request.
 type BroadcastCustomEventResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Broadcasts a `CustomEvent` to all WebSocket clients. Receivers are clients which are identified and subscribed.

--- a/api/requests/general/xx_generated.callvendorrequest.go
+++ b/api/requests/general/xx_generated.callvendorrequest.go
@@ -2,8 +2,6 @@
 
 package general
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the CallVendorRequest request.
 type CallVendorRequestParams struct {
 	// Object containing appropriate request data
@@ -39,7 +37,7 @@ func (o *CallVendorRequestParams) GetRequestName() string {
 
 // Represents the response body for the CallVendorRequest request.
 type CallVendorRequestResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Echoed of `requestType`
 	RequestType string `json:"requestType,omitempty"`

--- a/api/requests/general/xx_generated.gethotkeylist.go
+++ b/api/requests/general/xx_generated.gethotkeylist.go
@@ -2,8 +2,6 @@
 
 package general
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetHotkeyList request.
 type GetHotkeyListParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetHotkeyListParams) GetRequestName() string {
 
 // Represents the response body for the GetHotkeyList request.
 type GetHotkeyListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Array of hotkey names
 	Hotkeys []string `json:"hotkeys,omitempty"`

--- a/api/requests/general/xx_generated.getstats.go
+++ b/api/requests/general/xx_generated.getstats.go
@@ -2,8 +2,6 @@
 
 package general
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetStats request.
 type GetStatsParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetStatsParams) GetRequestName() string {
 
 // Represents the response body for the GetStats request.
 type GetStatsResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Current FPS being rendered
 	ActiveFps float64 `json:"activeFps,omitempty"`

--- a/api/requests/general/xx_generated.getversion.go
+++ b/api/requests/general/xx_generated.getversion.go
@@ -2,8 +2,6 @@
 
 package general
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetVersion request.
 type GetVersionParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetVersionParams) GetRequestName() string {
 
 // Represents the response body for the GetVersion request.
 type GetVersionResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Array of available RPC requests for the currently negotiated RPC version
 	AvailableRequests []string `json:"availableRequests,omitempty"`

--- a/api/requests/general/xx_generated.sleep.go
+++ b/api/requests/general/xx_generated.sleep.go
@@ -2,8 +2,6 @@
 
 package general
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the Sleep request.
 type SleepParams struct {
 	// Number of frames to sleep for (if `SERIAL_FRAME` mode)
@@ -32,7 +30,7 @@ func (o *SleepParams) GetRequestName() string {
 
 // Represents the response body for the Sleep request.
 type SleepResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sleeps for a time duration or number of frames. Only available in request batches with types `SERIAL_REALTIME` or

--- a/api/requests/general/xx_generated.triggerhotkeybykeysequence.go
+++ b/api/requests/general/xx_generated.triggerhotkeybykeysequence.go
@@ -2,10 +2,7 @@
 
 package general
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the TriggerHotkeyByKeySequence request.
 type TriggerHotkeyByKeySequenceParams struct {
@@ -38,7 +35,7 @@ func (o *TriggerHotkeyByKeySequenceParams) GetRequestName() string {
 
 // Represents the response body for the TriggerHotkeyByKeySequence request.
 type TriggerHotkeyByKeySequenceResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Triggers a hotkey using a sequence of keys.

--- a/api/requests/general/xx_generated.triggerhotkeybyname.go
+++ b/api/requests/general/xx_generated.triggerhotkeybyname.go
@@ -2,8 +2,6 @@
 
 package general
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the TriggerHotkeyByName request.
 type TriggerHotkeyByNameParams struct {
 	// Name of the hotkey to trigger
@@ -25,7 +23,7 @@ func (o *TriggerHotkeyByNameParams) GetRequestName() string {
 
 // Represents the response body for the TriggerHotkeyByName request.
 type TriggerHotkeyByNameResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Triggers a hotkey using its name. See `GetHotkeyList`

--- a/api/requests/general/zz_generated.client.go
+++ b/api/requests/general/zz_generated.client.go
@@ -4,6 +4,8 @@ package general
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'general' requests.
 type Client struct {
 	*api.Client

--- a/api/requests/inputs/xx_generated.createinput.go
+++ b/api/requests/inputs/xx_generated.createinput.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the CreateInput request.
 type CreateInputParams struct {
 	// The kind of input to be created
@@ -53,7 +51,7 @@ func (o *CreateInputParams) GetRequestName() string {
 
 // Represents the response body for the CreateInput request.
 type CreateInputResponse struct {
-	api.ResponseCommon
+	_response
 
 	// ID of the newly created scene item
 	SceneItemId int `json:"sceneItemId,omitempty"`

--- a/api/requests/inputs/xx_generated.getinputaudiobalance.go
+++ b/api/requests/inputs/xx_generated.getinputaudiobalance.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetInputAudioBalance request.
 type GetInputAudioBalanceParams struct {
 	// Name of the input to get the audio balance of
@@ -25,7 +23,7 @@ func (o *GetInputAudioBalanceParams) GetRequestName() string {
 
 // Represents the response body for the GetInputAudioBalance request.
 type GetInputAudioBalanceResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Audio balance value from 0.0-1.0
 	InputAudioBalance float64 `json:"inputAudioBalance,omitempty"`

--- a/api/requests/inputs/xx_generated.getinputaudiomonitortype.go
+++ b/api/requests/inputs/xx_generated.getinputaudiomonitortype.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetInputAudioMonitorType request.
 type GetInputAudioMonitorTypeParams struct {
 	// Name of the input to get the audio monitor type of
@@ -25,7 +23,7 @@ func (o *GetInputAudioMonitorTypeParams) GetRequestName() string {
 
 // Represents the response body for the GetInputAudioMonitorType request.
 type GetInputAudioMonitorTypeResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Audio monitor type
 	MonitorType string `json:"monitorType,omitempty"`

--- a/api/requests/inputs/xx_generated.getinputaudiosyncoffset.go
+++ b/api/requests/inputs/xx_generated.getinputaudiosyncoffset.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetInputAudioSyncOffset request.
 type GetInputAudioSyncOffsetParams struct {
 	// Name of the input to get the audio sync offset of
@@ -25,7 +23,7 @@ func (o *GetInputAudioSyncOffsetParams) GetRequestName() string {
 
 // Represents the response body for the GetInputAudioSyncOffset request.
 type GetInputAudioSyncOffsetResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Audio sync offset in milliseconds
 	InputAudioSyncOffset float64 `json:"inputAudioSyncOffset,omitempty"`

--- a/api/requests/inputs/xx_generated.getinputaudiotracks.go
+++ b/api/requests/inputs/xx_generated.getinputaudiotracks.go
@@ -2,10 +2,7 @@
 
 package inputs
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the GetInputAudioTracks request.
 type GetInputAudioTracksParams struct {
@@ -28,7 +25,7 @@ func (o *GetInputAudioTracksParams) GetRequestName() string {
 
 // Represents the response body for the GetInputAudioTracks request.
 type GetInputAudioTracksResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Object of audio tracks and associated enable states
 	InputAudioTracks *typedefs.InputAudioTracks `json:"inputAudioTracks,omitempty"`

--- a/api/requests/inputs/xx_generated.getinputdefaultsettings.go
+++ b/api/requests/inputs/xx_generated.getinputdefaultsettings.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetInputDefaultSettings request.
 type GetInputDefaultSettingsParams struct {
 	// Input kind to get the default settings for
@@ -25,7 +23,7 @@ func (o *GetInputDefaultSettingsParams) GetRequestName() string {
 
 // Represents the response body for the GetInputDefaultSettings request.
 type GetInputDefaultSettingsResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Object of default settings for the input kind
 	DefaultInputSettings map[string]any `json:"defaultInputSettings,omitempty"`

--- a/api/requests/inputs/xx_generated.getinputkindlist.go
+++ b/api/requests/inputs/xx_generated.getinputkindlist.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetInputKindList request.
 type GetInputKindListParams struct {
 	// True == Return all kinds as unversioned, False == Return with version suffixes (if available)
@@ -25,7 +23,7 @@ func (o *GetInputKindListParams) GetRequestName() string {
 
 // Represents the response body for the GetInputKindList request.
 type GetInputKindListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Array of input kinds
 	InputKinds []string `json:"inputKinds,omitempty"`

--- a/api/requests/inputs/xx_generated.getinputlist.go
+++ b/api/requests/inputs/xx_generated.getinputlist.go
@@ -2,10 +2,7 @@
 
 package inputs
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the GetInputList request.
 type GetInputListParams struct {
@@ -28,7 +25,7 @@ func (o *GetInputListParams) GetRequestName() string {
 
 // Represents the response body for the GetInputList request.
 type GetInputListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Array of inputs
 	Inputs []*typedefs.Input `json:"inputs,omitempty"`

--- a/api/requests/inputs/xx_generated.getinputmute.go
+++ b/api/requests/inputs/xx_generated.getinputmute.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetInputMute request.
 type GetInputMuteParams struct {
 	// Name of input to get the mute state of
@@ -25,7 +23,7 @@ func (o *GetInputMuteParams) GetRequestName() string {
 
 // Represents the response body for the GetInputMute request.
 type GetInputMuteResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the input is muted
 	InputMuted bool `json:"inputMuted,omitempty"`

--- a/api/requests/inputs/xx_generated.getinputpropertieslistpropertyitems.go
+++ b/api/requests/inputs/xx_generated.getinputpropertieslistpropertyitems.go
@@ -2,10 +2,7 @@
 
 package inputs
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the GetInputPropertiesListPropertyItems request.
 type GetInputPropertiesListPropertyItemsParams struct {
@@ -38,7 +35,7 @@ func (o *GetInputPropertiesListPropertyItemsParams) GetRequestName() string {
 
 // Represents the response body for the GetInputPropertiesListPropertyItems request.
 type GetInputPropertiesListPropertyItemsResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Array of items in the list property
 	PropertyItems []*typedefs.PropertyItem `json:"propertyItems,omitempty"`

--- a/api/requests/inputs/xx_generated.getinputsettings.go
+++ b/api/requests/inputs/xx_generated.getinputsettings.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetInputSettings request.
 type GetInputSettingsParams struct {
 	// Name of the input to get the settings of
@@ -25,7 +23,7 @@ func (o *GetInputSettingsParams) GetRequestName() string {
 
 // Represents the response body for the GetInputSettings request.
 type GetInputSettingsResponse struct {
-	api.ResponseCommon
+	_response
 
 	// The kind of the input
 	InputKind string `json:"inputKind,omitempty"`

--- a/api/requests/inputs/xx_generated.getinputvolume.go
+++ b/api/requests/inputs/xx_generated.getinputvolume.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetInputVolume request.
 type GetInputVolumeParams struct {
 	// Name of the input to get the volume of
@@ -25,7 +23,7 @@ func (o *GetInputVolumeParams) GetRequestName() string {
 
 // Represents the response body for the GetInputVolume request.
 type GetInputVolumeResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Volume setting in dB
 	InputVolumeDb float64 `json:"inputVolumeDb,omitempty"`

--- a/api/requests/inputs/xx_generated.getspecialinputs.go
+++ b/api/requests/inputs/xx_generated.getspecialinputs.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetSpecialInputs request.
 type GetSpecialInputsParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetSpecialInputsParams) GetRequestName() string {
 
 // Represents the response body for the GetSpecialInputs request.
 type GetSpecialInputsResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Name of the Desktop Audio input
 	Desktop1 string `json:"desktop1,omitempty"`

--- a/api/requests/inputs/xx_generated.pressinputpropertiesbutton.go
+++ b/api/requests/inputs/xx_generated.pressinputpropertiesbutton.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the PressInputPropertiesButton request.
 type PressInputPropertiesButtonParams struct {
 	// Name of the input
@@ -32,7 +30,7 @@ func (o *PressInputPropertiesButtonParams) GetRequestName() string {
 
 // Represents the response body for the PressInputPropertiesButton request.
 type PressInputPropertiesButtonResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/inputs/xx_generated.removeinput.go
+++ b/api/requests/inputs/xx_generated.removeinput.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the RemoveInput request.
 type RemoveInputParams struct {
 	// Name of the input to remove
@@ -25,7 +23,7 @@ func (o *RemoveInputParams) GetRequestName() string {
 
 // Represents the response body for the RemoveInput request.
 type RemoveInputResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/inputs/xx_generated.setinputaudiobalance.go
+++ b/api/requests/inputs/xx_generated.setinputaudiobalance.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetInputAudioBalance request.
 type SetInputAudioBalanceParams struct {
 	// New audio balance value
@@ -32,7 +30,7 @@ func (o *SetInputAudioBalanceParams) GetRequestName() string {
 
 // Represents the response body for the SetInputAudioBalance request.
 type SetInputAudioBalanceResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the audio balance of an input.

--- a/api/requests/inputs/xx_generated.setinputaudiomonitortype.go
+++ b/api/requests/inputs/xx_generated.setinputaudiomonitortype.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetInputAudioMonitorType request.
 type SetInputAudioMonitorTypeParams struct {
 	// Name of the input to set the audio monitor type of
@@ -32,7 +30,7 @@ func (o *SetInputAudioMonitorTypeParams) GetRequestName() string {
 
 // Represents the response body for the SetInputAudioMonitorType request.
 type SetInputAudioMonitorTypeResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the audio monitor type of an input.

--- a/api/requests/inputs/xx_generated.setinputaudiosyncoffset.go
+++ b/api/requests/inputs/xx_generated.setinputaudiosyncoffset.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetInputAudioSyncOffset request.
 type SetInputAudioSyncOffsetParams struct {
 	// New audio sync offset in milliseconds
@@ -32,7 +30,7 @@ func (o *SetInputAudioSyncOffsetParams) GetRequestName() string {
 
 // Represents the response body for the SetInputAudioSyncOffset request.
 type SetInputAudioSyncOffsetResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the audio sync offset of an input.

--- a/api/requests/inputs/xx_generated.setinputaudiotracks.go
+++ b/api/requests/inputs/xx_generated.setinputaudiotracks.go
@@ -2,10 +2,7 @@
 
 package inputs
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the SetInputAudioTracks request.
 type SetInputAudioTracksParams struct {
@@ -35,7 +32,7 @@ func (o *SetInputAudioTracksParams) GetRequestName() string {
 
 // Represents the response body for the SetInputAudioTracks request.
 type SetInputAudioTracksResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the enable state of audio tracks of an input.

--- a/api/requests/inputs/xx_generated.setinputmute.go
+++ b/api/requests/inputs/xx_generated.setinputmute.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetInputMute request.
 type SetInputMuteParams struct {
 	// Whether to mute the input or not
@@ -32,7 +30,7 @@ func (o *SetInputMuteParams) GetRequestName() string {
 
 // Represents the response body for the SetInputMute request.
 type SetInputMuteResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the audio mute state of an input.

--- a/api/requests/inputs/xx_generated.setinputname.go
+++ b/api/requests/inputs/xx_generated.setinputname.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetInputName request.
 type SetInputNameParams struct {
 	// Current input name
@@ -32,7 +30,7 @@ func (o *SetInputNameParams) GetRequestName() string {
 
 // Represents the response body for the SetInputName request.
 type SetInputNameResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the name of an input (rename).

--- a/api/requests/inputs/xx_generated.setinputsettings.go
+++ b/api/requests/inputs/xx_generated.setinputsettings.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetInputSettings request.
 type SetInputSettingsParams struct {
 	// Name of the input to set the settings of
@@ -40,7 +38,7 @@ func (o *SetInputSettingsParams) GetRequestName() string {
 
 // Represents the response body for the SetInputSettings request.
 type SetInputSettingsResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the settings of an input.

--- a/api/requests/inputs/xx_generated.setinputvolume.go
+++ b/api/requests/inputs/xx_generated.setinputvolume.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetInputVolume request.
 type SetInputVolumeParams struct {
 	// Name of the input to set the volume of
@@ -39,7 +37,7 @@ func (o *SetInputVolumeParams) GetRequestName() string {
 
 // Represents the response body for the SetInputVolume request.
 type SetInputVolumeResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the volume setting of an input.

--- a/api/requests/inputs/xx_generated.toggleinputmute.go
+++ b/api/requests/inputs/xx_generated.toggleinputmute.go
@@ -2,8 +2,6 @@
 
 package inputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the ToggleInputMute request.
 type ToggleInputMuteParams struct {
 	// Name of the input to toggle the mute state of
@@ -25,7 +23,7 @@ func (o *ToggleInputMuteParams) GetRequestName() string {
 
 // Represents the response body for the ToggleInputMute request.
 type ToggleInputMuteResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the input has been muted or unmuted
 	InputMuted bool `json:"inputMuted,omitempty"`

--- a/api/requests/inputs/zz_generated.client.go
+++ b/api/requests/inputs/zz_generated.client.go
@@ -4,6 +4,8 @@ package inputs
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'inputs' requests.
 type Client struct {
 	*api.Client

--- a/api/requests/mediainputs/xx_generated.getmediainputstatus.go
+++ b/api/requests/mediainputs/xx_generated.getmediainputstatus.go
@@ -2,8 +2,6 @@
 
 package mediainputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetMediaInputStatus request.
 type GetMediaInputStatusParams struct {
 	// Name of the media input
@@ -25,7 +23,7 @@ func (o *GetMediaInputStatusParams) GetRequestName() string {
 
 // Represents the response body for the GetMediaInputStatus request.
 type GetMediaInputStatusResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Position of the cursor in milliseconds. `null` if not playing
 	MediaCursor float64 `json:"mediaCursor,omitempty"`

--- a/api/requests/mediainputs/xx_generated.offsetmediainputcursor.go
+++ b/api/requests/mediainputs/xx_generated.offsetmediainputcursor.go
@@ -2,8 +2,6 @@
 
 package mediainputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the OffsetMediaInputCursor request.
 type OffsetMediaInputCursorParams struct {
 	// Name of the media input
@@ -32,7 +30,7 @@ func (o *OffsetMediaInputCursorParams) GetRequestName() string {
 
 // Represents the response body for the OffsetMediaInputCursor request.
 type OffsetMediaInputCursorResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/mediainputs/xx_generated.setmediainputcursor.go
+++ b/api/requests/mediainputs/xx_generated.setmediainputcursor.go
@@ -2,8 +2,6 @@
 
 package mediainputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetMediaInputCursor request.
 type SetMediaInputCursorParams struct {
 	// Name of the media input
@@ -32,7 +30,7 @@ func (o *SetMediaInputCursorParams) GetRequestName() string {
 
 // Represents the response body for the SetMediaInputCursor request.
 type SetMediaInputCursorResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/mediainputs/xx_generated.triggermediainputaction.go
+++ b/api/requests/mediainputs/xx_generated.triggermediainputaction.go
@@ -2,8 +2,6 @@
 
 package mediainputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the TriggerMediaInputAction request.
 type TriggerMediaInputActionParams struct {
 	// Name of the media input
@@ -32,7 +30,7 @@ func (o *TriggerMediaInputActionParams) GetRequestName() string {
 
 // Represents the response body for the TriggerMediaInputAction request.
 type TriggerMediaInputActionResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Triggers an action on a media input.

--- a/api/requests/mediainputs/zz_generated.client.go
+++ b/api/requests/mediainputs/zz_generated.client.go
@@ -4,6 +4,8 @@ package mediainputs
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'media inputs' requests.
 type Client struct {
 	*api.Client

--- a/api/requests/outputs/xx_generated.getlastreplaybufferreplay.go
+++ b/api/requests/outputs/xx_generated.getlastreplaybufferreplay.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetLastReplayBufferReplay request.
 type GetLastReplayBufferReplayParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetLastReplayBufferReplayParams) GetRequestName() string {
 
 // Represents the response body for the GetLastReplayBufferReplay request.
 type GetLastReplayBufferReplayResponse struct {
-	api.ResponseCommon
+	_response
 
 	// File path
 	SavedReplayPath string `json:"savedReplayPath,omitempty"`

--- a/api/requests/outputs/xx_generated.getoutputlist.go
+++ b/api/requests/outputs/xx_generated.getoutputlist.go
@@ -2,10 +2,7 @@
 
 package outputs
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the GetOutputList request.
 type GetOutputListParams struct{}
@@ -17,7 +14,7 @@ func (o *GetOutputListParams) GetRequestName() string {
 
 // Represents the response body for the GetOutputList request.
 type GetOutputListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Array of outputs
 	Outputs []*typedefs.Output `json:"outputs,omitempty"`

--- a/api/requests/outputs/xx_generated.getoutputsettings.go
+++ b/api/requests/outputs/xx_generated.getoutputsettings.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetOutputSettings request.
 type GetOutputSettingsParams struct {
 	// Output name
@@ -25,7 +23,7 @@ func (o *GetOutputSettingsParams) GetRequestName() string {
 
 // Represents the response body for the GetOutputSettings request.
 type GetOutputSettingsResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Output settings
 	OutputSettings map[string]any `json:"outputSettings,omitempty"`

--- a/api/requests/outputs/xx_generated.getoutputstatus.go
+++ b/api/requests/outputs/xx_generated.getoutputstatus.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetOutputStatus request.
 type GetOutputStatusParams struct {
 	// Output name
@@ -25,7 +23,7 @@ func (o *GetOutputStatusParams) GetRequestName() string {
 
 // Represents the response body for the GetOutputStatus request.
 type GetOutputStatusResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the output is active
 	OutputActive bool `json:"outputActive,omitempty"`

--- a/api/requests/outputs/xx_generated.getreplaybufferstatus.go
+++ b/api/requests/outputs/xx_generated.getreplaybufferstatus.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetReplayBufferStatus request.
 type GetReplayBufferStatusParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetReplayBufferStatusParams) GetRequestName() string {
 
 // Represents the response body for the GetReplayBufferStatus request.
 type GetReplayBufferStatusResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the output is active
 	OutputActive bool `json:"outputActive,omitempty"`

--- a/api/requests/outputs/xx_generated.getvirtualcamstatus.go
+++ b/api/requests/outputs/xx_generated.getvirtualcamstatus.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetVirtualCamStatus request.
 type GetVirtualCamStatusParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetVirtualCamStatusParams) GetRequestName() string {
 
 // Represents the response body for the GetVirtualCamStatus request.
 type GetVirtualCamStatusResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the output is active
 	OutputActive bool `json:"outputActive,omitempty"`

--- a/api/requests/outputs/xx_generated.savereplaybuffer.go
+++ b/api/requests/outputs/xx_generated.savereplaybuffer.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SaveReplayBuffer request.
 type SaveReplayBufferParams struct{}
 
@@ -14,7 +12,7 @@ func (o *SaveReplayBufferParams) GetRequestName() string {
 
 // Represents the response body for the SaveReplayBuffer request.
 type SaveReplayBufferResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Saves the contents of the replay buffer output.

--- a/api/requests/outputs/xx_generated.setoutputsettings.go
+++ b/api/requests/outputs/xx_generated.setoutputsettings.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetOutputSettings request.
 type SetOutputSettingsParams struct {
 	// Output name
@@ -32,7 +30,7 @@ func (o *SetOutputSettingsParams) GetRequestName() string {
 
 // Represents the response body for the SetOutputSettings request.
 type SetOutputSettingsResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the settings of an output.

--- a/api/requests/outputs/xx_generated.startoutput.go
+++ b/api/requests/outputs/xx_generated.startoutput.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the StartOutput request.
 type StartOutputParams struct {
 	// Output name
@@ -25,7 +23,7 @@ func (o *StartOutputParams) GetRequestName() string {
 
 // Represents the response body for the StartOutput request.
 type StartOutputResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Starts an output.

--- a/api/requests/outputs/xx_generated.startreplaybuffer.go
+++ b/api/requests/outputs/xx_generated.startreplaybuffer.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the StartReplayBuffer request.
 type StartReplayBufferParams struct{}
 
@@ -14,7 +12,7 @@ func (o *StartReplayBufferParams) GetRequestName() string {
 
 // Represents the response body for the StartReplayBuffer request.
 type StartReplayBufferResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Starts the replay buffer output.

--- a/api/requests/outputs/xx_generated.startvirtualcam.go
+++ b/api/requests/outputs/xx_generated.startvirtualcam.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the StartVirtualCam request.
 type StartVirtualCamParams struct{}
 
@@ -14,7 +12,7 @@ func (o *StartVirtualCamParams) GetRequestName() string {
 
 // Represents the response body for the StartVirtualCam request.
 type StartVirtualCamResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Starts the virtualcam output.

--- a/api/requests/outputs/xx_generated.stopoutput.go
+++ b/api/requests/outputs/xx_generated.stopoutput.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the StopOutput request.
 type StopOutputParams struct {
 	// Output name
@@ -25,7 +23,7 @@ func (o *StopOutputParams) GetRequestName() string {
 
 // Represents the response body for the StopOutput request.
 type StopOutputResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Stops an output.

--- a/api/requests/outputs/xx_generated.stopreplaybuffer.go
+++ b/api/requests/outputs/xx_generated.stopreplaybuffer.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the StopReplayBuffer request.
 type StopReplayBufferParams struct{}
 
@@ -14,7 +12,7 @@ func (o *StopReplayBufferParams) GetRequestName() string {
 
 // Represents the response body for the StopReplayBuffer request.
 type StopReplayBufferResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Stops the replay buffer output.

--- a/api/requests/outputs/xx_generated.stopvirtualcam.go
+++ b/api/requests/outputs/xx_generated.stopvirtualcam.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the StopVirtualCam request.
 type StopVirtualCamParams struct{}
 
@@ -14,7 +12,7 @@ func (o *StopVirtualCamParams) GetRequestName() string {
 
 // Represents the response body for the StopVirtualCam request.
 type StopVirtualCamResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Stops the virtualcam output.

--- a/api/requests/outputs/xx_generated.toggleoutput.go
+++ b/api/requests/outputs/xx_generated.toggleoutput.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the ToggleOutput request.
 type ToggleOutputParams struct {
 	// Output name
@@ -25,7 +23,7 @@ func (o *ToggleOutputParams) GetRequestName() string {
 
 // Represents the response body for the ToggleOutput request.
 type ToggleOutputResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the output is active
 	OutputActive bool `json:"outputActive,omitempty"`

--- a/api/requests/outputs/xx_generated.togglereplaybuffer.go
+++ b/api/requests/outputs/xx_generated.togglereplaybuffer.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the ToggleReplayBuffer request.
 type ToggleReplayBufferParams struct{}
 
@@ -14,7 +12,7 @@ func (o *ToggleReplayBufferParams) GetRequestName() string {
 
 // Represents the response body for the ToggleReplayBuffer request.
 type ToggleReplayBufferResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the output is active
 	OutputActive bool `json:"outputActive,omitempty"`

--- a/api/requests/outputs/xx_generated.togglevirtualcam.go
+++ b/api/requests/outputs/xx_generated.togglevirtualcam.go
@@ -2,8 +2,6 @@
 
 package outputs
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the ToggleVirtualCam request.
 type ToggleVirtualCamParams struct{}
 
@@ -14,7 +12,7 @@ func (o *ToggleVirtualCamParams) GetRequestName() string {
 
 // Represents the response body for the ToggleVirtualCam request.
 type ToggleVirtualCamResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the output is active
 	OutputActive bool `json:"outputActive,omitempty"`

--- a/api/requests/outputs/zz_generated.client.go
+++ b/api/requests/outputs/zz_generated.client.go
@@ -4,6 +4,8 @@ package outputs
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'outputs' requests.
 type Client struct {
 	*api.Client

--- a/api/requests/record/xx_generated.getrecordstatus.go
+++ b/api/requests/record/xx_generated.getrecordstatus.go
@@ -2,8 +2,6 @@
 
 package record
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetRecordStatus request.
 type GetRecordStatusParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetRecordStatusParams) GetRequestName() string {
 
 // Represents the response body for the GetRecordStatus request.
 type GetRecordStatusResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the output is active
 	OutputActive bool `json:"outputActive,omitempty"`

--- a/api/requests/record/xx_generated.pauserecord.go
+++ b/api/requests/record/xx_generated.pauserecord.go
@@ -2,8 +2,6 @@
 
 package record
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the PauseRecord request.
 type PauseRecordParams struct{}
 
@@ -14,7 +12,7 @@ func (o *PauseRecordParams) GetRequestName() string {
 
 // Represents the response body for the PauseRecord request.
 type PauseRecordResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Pauses the record output.

--- a/api/requests/record/xx_generated.resumerecord.go
+++ b/api/requests/record/xx_generated.resumerecord.go
@@ -2,8 +2,6 @@
 
 package record
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the ResumeRecord request.
 type ResumeRecordParams struct{}
 
@@ -14,7 +12,7 @@ func (o *ResumeRecordParams) GetRequestName() string {
 
 // Represents the response body for the ResumeRecord request.
 type ResumeRecordResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Resumes the record output.

--- a/api/requests/record/xx_generated.startrecord.go
+++ b/api/requests/record/xx_generated.startrecord.go
@@ -2,8 +2,6 @@
 
 package record
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the StartRecord request.
 type StartRecordParams struct{}
 
@@ -14,7 +12,7 @@ func (o *StartRecordParams) GetRequestName() string {
 
 // Represents the response body for the StartRecord request.
 type StartRecordResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Starts the record output.

--- a/api/requests/record/xx_generated.stoprecord.go
+++ b/api/requests/record/xx_generated.stoprecord.go
@@ -2,8 +2,6 @@
 
 package record
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the StopRecord request.
 type StopRecordParams struct{}
 
@@ -14,7 +12,7 @@ func (o *StopRecordParams) GetRequestName() string {
 
 // Represents the response body for the StopRecord request.
 type StopRecordResponse struct {
-	api.ResponseCommon
+	_response
 
 	// File name for the saved recording
 	OutputPath string `json:"outputPath,omitempty"`

--- a/api/requests/record/xx_generated.togglerecord.go
+++ b/api/requests/record/xx_generated.togglerecord.go
@@ -2,8 +2,6 @@
 
 package record
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the ToggleRecord request.
 type ToggleRecordParams struct{}
 
@@ -14,7 +12,7 @@ func (o *ToggleRecordParams) GetRequestName() string {
 
 // Represents the response body for the ToggleRecord request.
 type ToggleRecordResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Toggles the status of the record output.

--- a/api/requests/record/xx_generated.togglerecordpause.go
+++ b/api/requests/record/xx_generated.togglerecordpause.go
@@ -2,8 +2,6 @@
 
 package record
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the ToggleRecordPause request.
 type ToggleRecordPauseParams struct{}
 
@@ -14,7 +12,7 @@ func (o *ToggleRecordPauseParams) GetRequestName() string {
 
 // Represents the response body for the ToggleRecordPause request.
 type ToggleRecordPauseResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Toggles pause on the record output.

--- a/api/requests/record/zz_generated.client.go
+++ b/api/requests/record/zz_generated.client.go
@@ -4,6 +4,8 @@ package record
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'record' requests.
 type Client struct {
 	*api.Client

--- a/api/requests/sceneitems/xx_generated.createsceneitem.go
+++ b/api/requests/sceneitems/xx_generated.createsceneitem.go
@@ -2,8 +2,6 @@
 
 package sceneitems
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the CreateSceneItem request.
 type CreateSceneItemParams struct {
 	// Enable state to apply to the scene item on creation
@@ -39,7 +37,7 @@ func (o *CreateSceneItemParams) GetRequestName() string {
 
 // Represents the response body for the CreateSceneItem request.
 type CreateSceneItemResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Numeric ID of the scene item
 	SceneItemId int `json:"sceneItemId,omitempty"`

--- a/api/requests/sceneitems/xx_generated.duplicatesceneitem.go
+++ b/api/requests/sceneitems/xx_generated.duplicatesceneitem.go
@@ -2,8 +2,6 @@
 
 package sceneitems
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the DuplicateSceneItem request.
 type DuplicateSceneItemParams struct {
 	// Name of the scene to create the duplicated item in
@@ -39,7 +37,7 @@ func (o *DuplicateSceneItemParams) GetRequestName() string {
 
 // Represents the response body for the DuplicateSceneItem request.
 type DuplicateSceneItemResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Numeric ID of the duplicated scene item
 	SceneItemId int `json:"sceneItemId,omitempty"`

--- a/api/requests/sceneitems/xx_generated.getgroupsceneitemlist.go
+++ b/api/requests/sceneitems/xx_generated.getgroupsceneitemlist.go
@@ -2,10 +2,7 @@
 
 package sceneitems
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the GetGroupSceneItemList request.
 type GetGroupSceneItemListParams struct {
@@ -28,7 +25,7 @@ func (o *GetGroupSceneItemListParams) GetRequestName() string {
 
 // Represents the response body for the GetGroupSceneItemList request.
 type GetGroupSceneItemListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Array of scene items in the group
 	SceneItems []*typedefs.SceneItem `json:"sceneItems,omitempty"`

--- a/api/requests/sceneitems/xx_generated.getsceneitemblendmode.go
+++ b/api/requests/sceneitems/xx_generated.getsceneitemblendmode.go
@@ -2,8 +2,6 @@
 
 package sceneitems
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetSceneItemBlendMode request.
 type GetSceneItemBlendModeParams struct {
 	// Numeric ID of the scene item
@@ -32,7 +30,7 @@ func (o *GetSceneItemBlendModeParams) GetRequestName() string {
 
 // Represents the response body for the GetSceneItemBlendMode request.
 type GetSceneItemBlendModeResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Current blend mode
 	SceneItemBlendMode string `json:"sceneItemBlendMode,omitempty"`

--- a/api/requests/sceneitems/xx_generated.getsceneitemenabled.go
+++ b/api/requests/sceneitems/xx_generated.getsceneitemenabled.go
@@ -2,8 +2,6 @@
 
 package sceneitems
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetSceneItemEnabled request.
 type GetSceneItemEnabledParams struct {
 	// Numeric ID of the scene item
@@ -32,7 +30,7 @@ func (o *GetSceneItemEnabledParams) GetRequestName() string {
 
 // Represents the response body for the GetSceneItemEnabled request.
 type GetSceneItemEnabledResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the scene item is enabled. `true` for enabled, `false` for disabled
 	SceneItemEnabled bool `json:"sceneItemEnabled,omitempty"`

--- a/api/requests/sceneitems/xx_generated.getsceneitemid.go
+++ b/api/requests/sceneitems/xx_generated.getsceneitemid.go
@@ -2,8 +2,6 @@
 
 package sceneitems
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetSceneItemId request.
 type GetSceneItemIdParams struct {
 	// Name of the scene or group to search in
@@ -39,7 +37,7 @@ func (o *GetSceneItemIdParams) GetRequestName() string {
 
 // Represents the response body for the GetSceneItemId request.
 type GetSceneItemIdResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Numeric ID of the scene item
 	SceneItemId int `json:"sceneItemId,omitempty"`

--- a/api/requests/sceneitems/xx_generated.getsceneitemindex.go
+++ b/api/requests/sceneitems/xx_generated.getsceneitemindex.go
@@ -2,8 +2,6 @@
 
 package sceneitems
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetSceneItemIndex request.
 type GetSceneItemIndexParams struct {
 	// Numeric ID of the scene item
@@ -32,7 +30,7 @@ func (o *GetSceneItemIndexParams) GetRequestName() string {
 
 // Represents the response body for the GetSceneItemIndex request.
 type GetSceneItemIndexResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Index position of the scene item
 	SceneItemIndex int `json:"sceneItemIndex,omitempty"`

--- a/api/requests/sceneitems/xx_generated.getsceneitemlist.go
+++ b/api/requests/sceneitems/xx_generated.getsceneitemlist.go
@@ -2,10 +2,7 @@
 
 package sceneitems
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the GetSceneItemList request.
 type GetSceneItemListParams struct {
@@ -28,7 +25,7 @@ func (o *GetSceneItemListParams) GetRequestName() string {
 
 // Represents the response body for the GetSceneItemList request.
 type GetSceneItemListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Array of scene items in the scene
 	SceneItems []*typedefs.SceneItem `json:"sceneItems,omitempty"`

--- a/api/requests/sceneitems/xx_generated.getsceneitemlocked.go
+++ b/api/requests/sceneitems/xx_generated.getsceneitemlocked.go
@@ -2,8 +2,6 @@
 
 package sceneitems
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetSceneItemLocked request.
 type GetSceneItemLockedParams struct {
 	// Numeric ID of the scene item
@@ -32,7 +30,7 @@ func (o *GetSceneItemLockedParams) GetRequestName() string {
 
 // Represents the response body for the GetSceneItemLocked request.
 type GetSceneItemLockedResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the scene item is locked. `true` for locked, `false` for unlocked
 	SceneItemLocked bool `json:"sceneItemLocked,omitempty"`

--- a/api/requests/sceneitems/xx_generated.getsceneitemtransform.go
+++ b/api/requests/sceneitems/xx_generated.getsceneitemtransform.go
@@ -2,10 +2,7 @@
 
 package sceneitems
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the GetSceneItemTransform request.
 type GetSceneItemTransformParams struct {
@@ -35,7 +32,7 @@ func (o *GetSceneItemTransformParams) GetRequestName() string {
 
 // Represents the response body for the GetSceneItemTransform request.
 type GetSceneItemTransformResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Object containing scene item transform info
 	SceneItemTransform *typedefs.SceneItemTransform `json:"sceneItemTransform,omitempty"`

--- a/api/requests/sceneitems/xx_generated.removesceneitem.go
+++ b/api/requests/sceneitems/xx_generated.removesceneitem.go
@@ -2,8 +2,6 @@
 
 package sceneitems
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the RemoveSceneItem request.
 type RemoveSceneItemParams struct {
 	// Numeric ID of the scene item
@@ -32,7 +30,7 @@ func (o *RemoveSceneItemParams) GetRequestName() string {
 
 // Represents the response body for the RemoveSceneItem request.
 type RemoveSceneItemResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/sceneitems/xx_generated.setsceneitemblendmode.go
+++ b/api/requests/sceneitems/xx_generated.setsceneitemblendmode.go
@@ -2,8 +2,6 @@
 
 package sceneitems
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetSceneItemBlendMode request.
 type SetSceneItemBlendModeParams struct {
 	// New blend mode
@@ -39,7 +37,7 @@ func (o *SetSceneItemBlendModeParams) GetRequestName() string {
 
 // Represents the response body for the SetSceneItemBlendMode request.
 type SetSceneItemBlendModeResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/sceneitems/xx_generated.setsceneitemenabled.go
+++ b/api/requests/sceneitems/xx_generated.setsceneitemenabled.go
@@ -2,8 +2,6 @@
 
 package sceneitems
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetSceneItemEnabled request.
 type SetSceneItemEnabledParams struct {
 	// New enable state of the scene item
@@ -39,7 +37,7 @@ func (o *SetSceneItemEnabledParams) GetRequestName() string {
 
 // Represents the response body for the SetSceneItemEnabled request.
 type SetSceneItemEnabledResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/sceneitems/xx_generated.setsceneitemindex.go
+++ b/api/requests/sceneitems/xx_generated.setsceneitemindex.go
@@ -2,8 +2,6 @@
 
 package sceneitems
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetSceneItemIndex request.
 type SetSceneItemIndexParams struct {
 	// Numeric ID of the scene item
@@ -39,7 +37,7 @@ func (o *SetSceneItemIndexParams) GetRequestName() string {
 
 // Represents the response body for the SetSceneItemIndex request.
 type SetSceneItemIndexResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/sceneitems/xx_generated.setsceneitemlocked.go
+++ b/api/requests/sceneitems/xx_generated.setsceneitemlocked.go
@@ -2,8 +2,6 @@
 
 package sceneitems
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetSceneItemLocked request.
 type SetSceneItemLockedParams struct {
 	// Numeric ID of the scene item
@@ -39,7 +37,7 @@ func (o *SetSceneItemLockedParams) GetRequestName() string {
 
 // Represents the response body for the SetSceneItemLocked request.
 type SetSceneItemLockedResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/sceneitems/xx_generated.setsceneitemtransform.go
+++ b/api/requests/sceneitems/xx_generated.setsceneitemtransform.go
@@ -2,10 +2,7 @@
 
 package sceneitems
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the SetSceneItemTransform request.
 type SetSceneItemTransformParams struct {
@@ -45,7 +42,7 @@ func (o *SetSceneItemTransformParams) GetRequestName() string {
 
 // Represents the response body for the SetSceneItemTransform request.
 type SetSceneItemTransformResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the transform and crop info of a scene item.

--- a/api/requests/sceneitems/zz_generated.client.go
+++ b/api/requests/sceneitems/zz_generated.client.go
@@ -4,6 +4,8 @@ package sceneitems
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'scene items' requests.
 type Client struct {
 	*api.Client

--- a/api/requests/scenes/xx_generated.createscene.go
+++ b/api/requests/scenes/xx_generated.createscene.go
@@ -2,8 +2,6 @@
 
 package scenes
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the CreateScene request.
 type CreateSceneParams struct {
 	// Name for the new scene
@@ -25,7 +23,7 @@ func (o *CreateSceneParams) GetRequestName() string {
 
 // Represents the response body for the CreateScene request.
 type CreateSceneResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Creates a new scene in OBS.

--- a/api/requests/scenes/xx_generated.getcurrentpreviewscene.go
+++ b/api/requests/scenes/xx_generated.getcurrentpreviewscene.go
@@ -2,8 +2,6 @@
 
 package scenes
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetCurrentPreviewScene request.
 type GetCurrentPreviewSceneParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetCurrentPreviewSceneParams) GetRequestName() string {
 
 // Represents the response body for the GetCurrentPreviewScene request.
 type GetCurrentPreviewSceneResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Current preview scene
 	CurrentPreviewSceneName string `json:"currentPreviewSceneName,omitempty"`

--- a/api/requests/scenes/xx_generated.getcurrentprogramscene.go
+++ b/api/requests/scenes/xx_generated.getcurrentprogramscene.go
@@ -2,8 +2,6 @@
 
 package scenes
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetCurrentProgramScene request.
 type GetCurrentProgramSceneParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetCurrentProgramSceneParams) GetRequestName() string {
 
 // Represents the response body for the GetCurrentProgramScene request.
 type GetCurrentProgramSceneResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Current program scene
 	CurrentProgramSceneName string `json:"currentProgramSceneName,omitempty"`

--- a/api/requests/scenes/xx_generated.getgrouplist.go
+++ b/api/requests/scenes/xx_generated.getgrouplist.go
@@ -2,8 +2,6 @@
 
 package scenes
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetGroupList request.
 type GetGroupListParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetGroupListParams) GetRequestName() string {
 
 // Represents the response body for the GetGroupList request.
 type GetGroupListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Array of group names
 	Groups []string `json:"groups,omitempty"`

--- a/api/requests/scenes/xx_generated.getscenelist.go
+++ b/api/requests/scenes/xx_generated.getscenelist.go
@@ -2,10 +2,7 @@
 
 package scenes
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the GetSceneList request.
 type GetSceneListParams struct{}
@@ -17,7 +14,7 @@ func (o *GetSceneListParams) GetRequestName() string {
 
 // Represents the response body for the GetSceneList request.
 type GetSceneListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Current preview scene. `null` if not in studio mode
 	CurrentPreviewSceneName string `json:"currentPreviewSceneName,omitempty"`

--- a/api/requests/scenes/xx_generated.getscenescenetransitionoverride.go
+++ b/api/requests/scenes/xx_generated.getscenescenetransitionoverride.go
@@ -2,8 +2,6 @@
 
 package scenes
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetSceneSceneTransitionOverride request.
 type GetSceneSceneTransitionOverrideParams struct {
 	// Name of the scene
@@ -25,7 +23,7 @@ func (o *GetSceneSceneTransitionOverrideParams) GetRequestName() string {
 
 // Represents the response body for the GetSceneSceneTransitionOverride request.
 type GetSceneSceneTransitionOverrideResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Duration of the overridden scene transition, else `null`
 	TransitionDuration float64 `json:"transitionDuration,omitempty"`

--- a/api/requests/scenes/xx_generated.removescene.go
+++ b/api/requests/scenes/xx_generated.removescene.go
@@ -2,8 +2,6 @@
 
 package scenes
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the RemoveScene request.
 type RemoveSceneParams struct {
 	// Name of the scene to remove
@@ -25,7 +23,7 @@ func (o *RemoveSceneParams) GetRequestName() string {
 
 // Represents the response body for the RemoveScene request.
 type RemoveSceneResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Removes a scene from OBS.

--- a/api/requests/scenes/xx_generated.setcurrentpreviewscene.go
+++ b/api/requests/scenes/xx_generated.setcurrentpreviewscene.go
@@ -2,8 +2,6 @@
 
 package scenes
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetCurrentPreviewScene request.
 type SetCurrentPreviewSceneParams struct {
 	// Scene to set as the current preview scene
@@ -25,7 +23,7 @@ func (o *SetCurrentPreviewSceneParams) GetRequestName() string {
 
 // Represents the response body for the SetCurrentPreviewScene request.
 type SetCurrentPreviewSceneResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/scenes/xx_generated.setcurrentprogramscene.go
+++ b/api/requests/scenes/xx_generated.setcurrentprogramscene.go
@@ -2,8 +2,6 @@
 
 package scenes
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetCurrentProgramScene request.
 type SetCurrentProgramSceneParams struct {
 	// Scene to set as the current program scene
@@ -25,7 +23,7 @@ func (o *SetCurrentProgramSceneParams) GetRequestName() string {
 
 // Represents the response body for the SetCurrentProgramScene request.
 type SetCurrentProgramSceneResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the current program scene.

--- a/api/requests/scenes/xx_generated.setscenename.go
+++ b/api/requests/scenes/xx_generated.setscenename.go
@@ -2,8 +2,6 @@
 
 package scenes
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetSceneName request.
 type SetSceneNameParams struct {
 	// New name for the scene
@@ -32,7 +30,7 @@ func (o *SetSceneNameParams) GetRequestName() string {
 
 // Represents the response body for the SetSceneName request.
 type SetSceneNameResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the name of a scene (rename).

--- a/api/requests/scenes/xx_generated.setscenescenetransitionoverride.go
+++ b/api/requests/scenes/xx_generated.setscenescenetransitionoverride.go
@@ -2,8 +2,6 @@
 
 package scenes
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetSceneSceneTransitionOverride request.
 type SetSceneSceneTransitionOverrideParams struct {
 	// Name of the scene
@@ -42,7 +40,7 @@ func (o *SetSceneSceneTransitionOverrideParams) GetRequestName() string {
 
 // Represents the response body for the SetSceneSceneTransitionOverride request.
 type SetSceneSceneTransitionOverrideResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Gets the scene transition overridden for a scene.

--- a/api/requests/scenes/zz_generated.client.go
+++ b/api/requests/scenes/zz_generated.client.go
@@ -4,6 +4,8 @@ package scenes
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'scenes' requests.
 type Client struct {
 	*api.Client

--- a/api/requests/sources/xx_generated.getsourceactive.go
+++ b/api/requests/sources/xx_generated.getsourceactive.go
@@ -2,8 +2,6 @@
 
 package sources
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetSourceActive request.
 type GetSourceActiveParams struct {
 	// Name of the source to get the active state of
@@ -25,7 +23,7 @@ func (o *GetSourceActiveParams) GetRequestName() string {
 
 // Represents the response body for the GetSourceActive request.
 type GetSourceActiveResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the source is showing in Program
 	VideoActive bool `json:"videoActive,omitempty"`

--- a/api/requests/sources/xx_generated.getsourcescreenshot.go
+++ b/api/requests/sources/xx_generated.getsourcescreenshot.go
@@ -2,8 +2,6 @@
 
 package sources
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetSourceScreenshot request.
 type GetSourceScreenshotParams struct {
 	// Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that
@@ -54,7 +52,7 @@ func (o *GetSourceScreenshotParams) GetRequestName() string {
 
 // Represents the response body for the GetSourceScreenshot request.
 type GetSourceScreenshotResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Base64-encoded screenshot
 	ImageData string `json:"imageData,omitempty"`

--- a/api/requests/sources/xx_generated.savesourcescreenshot.go
+++ b/api/requests/sources/xx_generated.savesourcescreenshot.go
@@ -2,8 +2,6 @@
 
 package sources
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SaveSourceScreenshot request.
 type SaveSourceScreenshotParams struct {
 	// Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use "default" (whatever that
@@ -61,7 +59,7 @@ func (o *SaveSourceScreenshotParams) GetRequestName() string {
 
 // Represents the response body for the SaveSourceScreenshot request.
 type SaveSourceScreenshotResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Base64-encoded screenshot
 	ImageData string `json:"imageData,omitempty"`

--- a/api/requests/sources/zz_generated.client.go
+++ b/api/requests/sources/zz_generated.client.go
@@ -4,6 +4,8 @@ package sources
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'sources' requests.
 type Client struct {
 	*api.Client

--- a/api/requests/stream/xx_generated.getstreamstatus.go
+++ b/api/requests/stream/xx_generated.getstreamstatus.go
@@ -2,8 +2,6 @@
 
 package stream
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetStreamStatus request.
 type GetStreamStatusParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetStreamStatusParams) GetRequestName() string {
 
 // Represents the response body for the GetStreamStatus request.
 type GetStreamStatusResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the output is active
 	OutputActive bool `json:"outputActive,omitempty"`

--- a/api/requests/stream/xx_generated.sendstreamcaption.go
+++ b/api/requests/stream/xx_generated.sendstreamcaption.go
@@ -2,8 +2,6 @@
 
 package stream
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SendStreamCaption request.
 type SendStreamCaptionParams struct {
 	// Caption text
@@ -25,7 +23,7 @@ func (o *SendStreamCaptionParams) GetRequestName() string {
 
 // Represents the response body for the SendStreamCaption request.
 type SendStreamCaptionResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sends CEA-608 caption text over the stream output.

--- a/api/requests/stream/xx_generated.startstream.go
+++ b/api/requests/stream/xx_generated.startstream.go
@@ -2,8 +2,6 @@
 
 package stream
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the StartStream request.
 type StartStreamParams struct{}
 
@@ -14,7 +12,7 @@ func (o *StartStreamParams) GetRequestName() string {
 
 // Represents the response body for the StartStream request.
 type StartStreamResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Starts the stream output.

--- a/api/requests/stream/xx_generated.stopstream.go
+++ b/api/requests/stream/xx_generated.stopstream.go
@@ -2,8 +2,6 @@
 
 package stream
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the StopStream request.
 type StopStreamParams struct{}
 
@@ -14,7 +12,7 @@ func (o *StopStreamParams) GetRequestName() string {
 
 // Represents the response body for the StopStream request.
 type StopStreamResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Stops the stream output.

--- a/api/requests/stream/xx_generated.togglestream.go
+++ b/api/requests/stream/xx_generated.togglestream.go
@@ -2,8 +2,6 @@
 
 package stream
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the ToggleStream request.
 type ToggleStreamParams struct{}
 
@@ -14,7 +12,7 @@ func (o *ToggleStreamParams) GetRequestName() string {
 
 // Represents the response body for the ToggleStream request.
 type ToggleStreamResponse struct {
-	api.ResponseCommon
+	_response
 
 	// New state of the stream output
 	OutputActive bool `json:"outputActive,omitempty"`

--- a/api/requests/stream/zz_generated.client.go
+++ b/api/requests/stream/zz_generated.client.go
@@ -4,6 +4,8 @@ package stream
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'stream' requests.
 type Client struct {
 	*api.Client

--- a/api/requests/transitions/xx_generated.getcurrentscenetransition.go
+++ b/api/requests/transitions/xx_generated.getcurrentscenetransition.go
@@ -2,8 +2,6 @@
 
 package transitions
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetCurrentSceneTransition request.
 type GetCurrentSceneTransitionParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetCurrentSceneTransitionParams) GetRequestName() string {
 
 // Represents the response body for the GetCurrentSceneTransition request.
 type GetCurrentSceneTransitionResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether the transition supports being configured
 	TransitionConfigurable bool `json:"transitionConfigurable,omitempty"`

--- a/api/requests/transitions/xx_generated.getcurrentscenetransitioncursor.go
+++ b/api/requests/transitions/xx_generated.getcurrentscenetransitioncursor.go
@@ -2,8 +2,6 @@
 
 package transitions
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetCurrentSceneTransitionCursor request.
 type GetCurrentSceneTransitionCursorParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetCurrentSceneTransitionCursorParams) GetRequestName() string {
 
 // Represents the response body for the GetCurrentSceneTransitionCursor request.
 type GetCurrentSceneTransitionCursorResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Cursor position, between 0.0 and 1.0
 	TransitionCursor float64 `json:"transitionCursor,omitempty"`

--- a/api/requests/transitions/xx_generated.getscenetransitionlist.go
+++ b/api/requests/transitions/xx_generated.getscenetransitionlist.go
@@ -2,10 +2,7 @@
 
 package transitions
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the GetSceneTransitionList request.
 type GetSceneTransitionListParams struct{}
@@ -17,7 +14,7 @@ func (o *GetSceneTransitionListParams) GetRequestName() string {
 
 // Represents the response body for the GetSceneTransitionList request.
 type GetSceneTransitionListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Kind of the current scene transition. Can be null
 	CurrentSceneTransitionKind string `json:"currentSceneTransitionKind,omitempty"`

--- a/api/requests/transitions/xx_generated.gettransitionkindlist.go
+++ b/api/requests/transitions/xx_generated.gettransitionkindlist.go
@@ -2,8 +2,6 @@
 
 package transitions
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetTransitionKindList request.
 type GetTransitionKindListParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetTransitionKindListParams) GetRequestName() string {
 
 // Represents the response body for the GetTransitionKindList request.
 type GetTransitionKindListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Array of transition kinds
 	TransitionKinds []string `json:"transitionKinds,omitempty"`

--- a/api/requests/transitions/xx_generated.setcurrentscenetransition.go
+++ b/api/requests/transitions/xx_generated.setcurrentscenetransition.go
@@ -2,8 +2,6 @@
 
 package transitions
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetCurrentSceneTransition request.
 type SetCurrentSceneTransitionParams struct {
 	// Name of the transition to make active
@@ -25,7 +23,7 @@ func (o *SetCurrentSceneTransitionParams) GetRequestName() string {
 
 // Represents the response body for the SetCurrentSceneTransition request.
 type SetCurrentSceneTransitionResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/transitions/xx_generated.setcurrentscenetransitionduration.go
+++ b/api/requests/transitions/xx_generated.setcurrentscenetransitionduration.go
@@ -2,8 +2,6 @@
 
 package transitions
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetCurrentSceneTransitionDuration request.
 type SetCurrentSceneTransitionDurationParams struct {
 	// Duration in milliseconds
@@ -28,7 +26,7 @@ func (o *SetCurrentSceneTransitionDurationParams) GetRequestName() string {
 
 // Represents the response body for the SetCurrentSceneTransitionDuration request.
 type SetCurrentSceneTransitionDurationResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the duration of the current scene transition, if it is not fixed.

--- a/api/requests/transitions/xx_generated.setcurrentscenetransitionsettings.go
+++ b/api/requests/transitions/xx_generated.setcurrentscenetransitionsettings.go
@@ -2,8 +2,6 @@
 
 package transitions
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetCurrentSceneTransitionSettings request.
 type SetCurrentSceneTransitionSettingsParams struct {
 	// Whether to overlay over the current settings or replace them
@@ -35,7 +33,7 @@ func (o *SetCurrentSceneTransitionSettingsParams) GetRequestName() string {
 
 // Represents the response body for the SetCurrentSceneTransitionSettings request.
 type SetCurrentSceneTransitionSettingsResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Sets the settings of the current scene transition.

--- a/api/requests/transitions/xx_generated.settbarposition.go
+++ b/api/requests/transitions/xx_generated.settbarposition.go
@@ -2,8 +2,6 @@
 
 package transitions
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetTBarPosition request.
 type SetTBarPositionParams struct {
 	// New position
@@ -32,7 +30,7 @@ func (o *SetTBarPositionParams) GetRequestName() string {
 
 // Represents the response body for the SetTBarPosition request.
 type SetTBarPositionResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/transitions/xx_generated.triggerstudiomodetransition.go
+++ b/api/requests/transitions/xx_generated.triggerstudiomodetransition.go
@@ -2,8 +2,6 @@
 
 package transitions
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the TriggerStudioModeTransition request.
 type TriggerStudioModeTransitionParams struct{}
 
@@ -14,7 +12,7 @@ func (o *TriggerStudioModeTransitionParams) GetRequestName() string {
 
 // Represents the response body for the TriggerStudioModeTransition request.
 type TriggerStudioModeTransitionResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Triggers the current scene transition. Same functionality as the `Transition` button in studio mode.

--- a/api/requests/transitions/zz_generated.client.go
+++ b/api/requests/transitions/zz_generated.client.go
@@ -4,6 +4,8 @@ package transitions
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'transitions' requests.
 type Client struct {
 	*api.Client

--- a/api/requests/ui/xx_generated.getmonitorlist.go
+++ b/api/requests/ui/xx_generated.getmonitorlist.go
@@ -2,10 +2,7 @@
 
 package ui
 
-import (
-	api "github.com/andreykaipov/goobs/api"
-	typedefs "github.com/andreykaipov/goobs/api/typedefs"
-)
+import typedefs "github.com/andreykaipov/goobs/api/typedefs"
 
 // Represents the request body for the GetMonitorList request.
 type GetMonitorListParams struct{}
@@ -17,7 +14,7 @@ func (o *GetMonitorListParams) GetRequestName() string {
 
 // Represents the response body for the GetMonitorList request.
 type GetMonitorListResponse struct {
-	api.ResponseCommon
+	_response
 
 	// a list of detected monitors with some information
 	Monitors []*typedefs.Monitor `json:"monitors,omitempty"`

--- a/api/requests/ui/xx_generated.getstudiomodeenabled.go
+++ b/api/requests/ui/xx_generated.getstudiomodeenabled.go
@@ -2,8 +2,6 @@
 
 package ui
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the GetStudioModeEnabled request.
 type GetStudioModeEnabledParams struct{}
 
@@ -14,7 +12,7 @@ func (o *GetStudioModeEnabledParams) GetRequestName() string {
 
 // Represents the response body for the GetStudioModeEnabled request.
 type GetStudioModeEnabledResponse struct {
-	api.ResponseCommon
+	_response
 
 	// Whether studio mode is enabled
 	StudioModeEnabled bool `json:"studioModeEnabled,omitempty"`

--- a/api/requests/ui/xx_generated.openinputfiltersdialog.go
+++ b/api/requests/ui/xx_generated.openinputfiltersdialog.go
@@ -2,8 +2,6 @@
 
 package ui
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the OpenInputFiltersDialog request.
 type OpenInputFiltersDialogParams struct {
 	// Name of the input to open the dialog of
@@ -25,7 +23,7 @@ func (o *OpenInputFiltersDialogParams) GetRequestName() string {
 
 // Represents the response body for the OpenInputFiltersDialog request.
 type OpenInputFiltersDialogResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Opens the filters dialog of an input.

--- a/api/requests/ui/xx_generated.openinputinteractdialog.go
+++ b/api/requests/ui/xx_generated.openinputinteractdialog.go
@@ -2,8 +2,6 @@
 
 package ui
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the OpenInputInteractDialog request.
 type OpenInputInteractDialogParams struct {
 	// Name of the input to open the dialog of
@@ -25,7 +23,7 @@ func (o *OpenInputInteractDialogParams) GetRequestName() string {
 
 // Represents the response body for the OpenInputInteractDialog request.
 type OpenInputInteractDialogResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Opens the interact dialog of an input.

--- a/api/requests/ui/xx_generated.openinputpropertiesdialog.go
+++ b/api/requests/ui/xx_generated.openinputpropertiesdialog.go
@@ -2,8 +2,6 @@
 
 package ui
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the OpenInputPropertiesDialog request.
 type OpenInputPropertiesDialogParams struct {
 	// Name of the input to open the dialog of
@@ -25,7 +23,7 @@ func (o *OpenInputPropertiesDialogParams) GetRequestName() string {
 
 // Represents the response body for the OpenInputPropertiesDialog request.
 type OpenInputPropertiesDialogResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Opens the properties dialog of an input.

--- a/api/requests/ui/xx_generated.opensourceprojector.go
+++ b/api/requests/ui/xx_generated.opensourceprojector.go
@@ -2,8 +2,6 @@
 
 package ui
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the OpenSourceProjector request.
 type OpenSourceProjectorParams struct {
 	// Monitor index, use `GetMonitorList` to obtain index
@@ -39,7 +37,7 @@ func (o *OpenSourceProjectorParams) GetRequestName() string {
 
 // Represents the response body for the OpenSourceProjector request.
 type OpenSourceProjectorResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/ui/xx_generated.openvideomixprojector.go
+++ b/api/requests/ui/xx_generated.openvideomixprojector.go
@@ -2,8 +2,6 @@
 
 package ui
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the OpenVideoMixProjector request.
 type OpenVideoMixProjectorParams struct {
 	// Monitor index, use `GetMonitorList` to obtain index
@@ -39,7 +37,7 @@ func (o *OpenVideoMixProjectorParams) GetRequestName() string {
 
 // Represents the response body for the OpenVideoMixProjector request.
 type OpenVideoMixProjectorResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 /*

--- a/api/requests/ui/xx_generated.setstudiomodeenabled.go
+++ b/api/requests/ui/xx_generated.setstudiomodeenabled.go
@@ -2,8 +2,6 @@
 
 package ui
 
-import api "github.com/andreykaipov/goobs/api"
-
 // Represents the request body for the SetStudioModeEnabled request.
 type SetStudioModeEnabledParams struct {
 	// True == Enabled, False == Disabled
@@ -25,7 +23,7 @@ func (o *SetStudioModeEnabledParams) GetRequestName() string {
 
 // Represents the response body for the SetStudioModeEnabled request.
 type SetStudioModeEnabledResponse struct {
-	api.ResponseCommon
+	_response
 }
 
 // Enables or disables studio mode

--- a/api/requests/ui/zz_generated.client.go
+++ b/api/requests/ui/zz_generated.client.go
@@ -4,6 +4,8 @@ package ui
 
 import api "github.com/andreykaipov/goobs/api"
 
+type _response = api.ResponseCommon
+
 // Client represents a client for 'ui' requests.
 type Client struct {
 	*api.Client

--- a/internal/generate/protocol/generate.go
+++ b/internal/generate/protocol/generate.go
@@ -40,8 +40,11 @@ func generateRequests(requests []*Request) {
 		// Generate the category-level client
 		client := NewFile(categoryClaustrophic)
 		client.HeaderComment("This file has been automatically generated. Don't edit it.")
-		client.Commentf("Client represents a client for '%s' requests.", category)
 		client.Add(
+			Type().Id("_response").Op("=").Qual(goobs+"/api", "ResponseCommon"),
+			Line(),
+			Commentf("Client represents a client for '%s' requests.", category),
+			Line(),
 			Type().Id("Client").Struct(
 				Op("*").Qual(goobs+"/api", "Client"),
 			),
@@ -144,7 +147,7 @@ func generateRequest(request *Request) (s *Statement, err error) {
 	s.Commentf("Represents the response body for the %s request.", name).Line()
 
 	respf := &ResponseField{}
-	respf.ValueName = "ResponseCommon"
+	respf.ValueName = "_response"
 	respf.ValueType = "~requests~" // internal type
 	request.ResponseFields = append(request.ResponseFields, respf)
 
@@ -401,7 +404,7 @@ func generateStructFromParams[F Field](origin string, s *Statement, name string,
 		case "Array<Object>":
 			fieldType = mapArrayObject(origin, name, f)
 		case "~requests~":
-			fieldType = Qual(goobs+"/api", fvn)
+			fieldType = Id(fvn)
 			embedded = true
 		default:
 			panic(fmt.Errorf("in struct %q, %q is of weird type %q", name, fvn, fvt))


### PR DESCRIPTION
This struct exposes `GetRaw()` but all its members are hidden so all it does is clutter the autocomplete menu