### PR TITLE
ci: capture exit 1 in update protocol workflow to cleanly exit

### DIFF
--- a/.github/workflows/update-protocol-version.yml
+++ b/.github/workflows/update-protocol-version.yml
@@ -27,7 +27,7 @@ jobs:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         base: main
       run: |
-        ./script/bump-protocol-version.sh
+        if ! ./script/bump-protocol-version.sh; then exit 0; fi
         bump=$(cat /tmp/.goobs.protocol.bump)
         next=$(cat /tmp/.goobs.protocol.next)
         branch="bump-protocol-version"


### PR DESCRIPTION
Now that we're consuming the latest protocol version, the CI complains there's nothing to update. While the script should still return `exit 1`, the CI should be green for this cron workflow.