### PR TITLE
docs: export Subclients embedded struct

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,7 +30,7 @@ type Client struct {
 	IncomingEvents chan any
 
 	client *api.Client
-	Subclients
+	Categories
 
 	conn               *websocket.Conn
 	host               string

--- a/client.go
+++ b/client.go
@@ -30,7 +30,7 @@ type Client struct {
 	IncomingEvents chan any
 
 	client *api.Client
-	subclients
+	Subclients
 
 	conn               *websocket.Conn
 	host               string

--- a/internal/generate/protocol/generate.go
+++ b/internal/generate/protocol/generate.go
@@ -93,7 +93,7 @@ func generateRequests(requests []*Request) {
 	// Write utils for the top-level client
 	f = NewFile("goobs")
 	f.HeaderComment("This file has been automatically generated. Don't edit it.")
-	f.Add(Type().Id("Subclients").Struct(topClientFields...))
+	f.Add(Type().Id("Categories").Struct(topClientFields...))
 	f.Add(Func().Id("setClients").Params(Id("c").Op("*").Id("Client")).Block(topClientSetters...))
 	if err := f.Save(fmt.Sprintf("%s/zz_generated.client.go", root)); err != nil {
 		panic(err)

--- a/internal/generate/protocol/generate.go
+++ b/internal/generate/protocol/generate.go
@@ -93,7 +93,7 @@ func generateRequests(requests []*Request) {
 	// Write utils for the top-level client
 	f = NewFile("goobs")
 	f.HeaderComment("This file has been automatically generated. Don't edit it.")
-	f.Add(Type().Id("subclients").Struct(topClientFields...))
+	f.Add(Type().Id("Subclients").Struct(topClientFields...))
 	f.Add(Func().Id("setClients").Params(Id("c").Op("*").Id("Client")).Block(topClientSetters...))
 	if err := f.Save(fmt.Sprintf("%s/zz_generated.client.go", root)); err != nil {
 		panic(err)

--- a/internal/generate/tests/main.go
+++ b/internal/generate/tests/main.go
@@ -92,7 +92,7 @@ func main() {
 		panic(err)
 	}
 
-	subclients := sortedKeys(structs["subclients"])
+	subclients := sortedKeys(structs["Subclients"])
 
 	for _, subclient := range subclients {
 		category := strings.ToLower(subclient)

--- a/internal/generate/tests/main.go
+++ b/internal/generate/tests/main.go
@@ -92,7 +92,7 @@ func main() {
 		panic(err)
 	}
 
-	subclients := sortedKeys(structs["Subclients"])
+	subclients := sortedKeys(structs["Categories"])
 
 	for _, subclient := range subclients {
 		category := strings.ToLower(subclient)

--- a/zz_generated.client.go
+++ b/zz_generated.client.go
@@ -18,7 +18,7 @@ import (
 	ui "github.com/andreykaipov/goobs/api/requests/ui"
 )
 
-type subclients struct {
+type Subclients struct {
 	Config      *config.Client
 	Filters     *filters.Client
 	General     *general.Client

--- a/zz_generated.client.go
+++ b/zz_generated.client.go
@@ -18,7 +18,7 @@ import (
 	ui "github.com/andreykaipov/goobs/api/requests/ui"
 )
 
-type Subclients struct {
+type Categories struct {
 	Config      *config.Client
 	Filters     *filters.Client
 	General     *general.Client


### PR DESCRIPTION
I don't automatically assume this is wanted / will be accepted. But I figured the change was easy enough to make that the discussion could be started with the PR.

Embedding a private struct creates the confusing effect of exporting the public fields of the embedded struct without having them show in documentation.

This has some discussion at the language / godoc level: https://github.com/golang/go/issues/6600

This commit exports the subclients field of `goobs.Client` so the available fields show in documentation.

I actually used this project as an example for how this behavior of godoc is confusing for developers: https://github.com/golang/go/issues/6600#issuecomment-1874538749