### PR TITLE
ci: use gh app token for release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, reopened, synchronize, closed]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, reopened, synchronize, closed]
-  pull_request_target:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
@@ -17,6 +15,11 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+    - uses: tibdex/github-app-token@v2
+      id: generate-token
+      with:
+        app_id: ${{ secrets.CATHY_CLOUD_APP_ID }}
+        private_key: ${{ secrets.CATHY_CLOUD_APP_PRIVATE_KEY }}
     - name: draft release
       id: draft-release
       uses: release-drafter/release-drafter@v5
@@ -24,7 +27,7 @@ jobs:
         config-name: release-drafter.yml
         disable-autolabeler: false
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
   # only when protocol changes
   publish-release-draft:


### PR DESCRIPTION
From the docs in https://github.com/release-drafter/release-drafter, I _think_ I need this to make the auto-labeling work for forks. 

This PR https://github.com/andreykaipov/goobs/pull/126 ran the `update-release-draft` workflow but silently failed with the following errors:

<img width="726" alt="image" src="https://github.com/andreykaipov/goobs/assets/9457739/aad57d82-efe8-4f5f-9d60-d2a708fb7f09">

---

Would be nice to only update the release draft on PR close, and run the auto-labeler on other events, but don't think I can do that yet based on [this comment](https://github.com/release-drafter/release-drafter/issues/1125#issuecomment-1324160912)