### PR TITLE
ci: use github.token for image retention

### DIFF
--- a/.github/workflows/image-retention-policy.yml
+++ b/.github/workflows/image-retention-policy.yml
@@ -8,19 +8,12 @@ jobs:
   clean-ghcr:
     runs-on: ubuntu-latest
     steps:
-    - uses: tibdex/github-app-token@v2
-      id: generate-token
-      with:
-        app_id: ${{ secrets.CATHY_CLOUD_APP_ID }}
-        private_key: ${{ secrets.CATHY_CLOUD_APP_PRIVATE_KEY }}
-
     - name: Delete old images
       uses: snok/container-retention-policy@v2
       with:
-        account-type: org
-        org-name: andreykaipov
-        token: ${{ steps.generate-token.outputs.token }}
+        account-type: personal
         token-type: github-token
+        token: ${{ github.token }}
         image-names: ${{ github.event.repository.name }}
         cut-off: one month ago EST
         untagged-only: true

--- a/.github/workflows/image-retention-policy.yml
+++ b/.github/workflows/image-retention-policy.yml
@@ -15,10 +15,12 @@ jobs:
         private_key: ${{ secrets.CATHY_CLOUD_APP_PRIVATE_KEY }}
 
     - name: Delete old images
-      uses: snok/container-retention-policy@main
+      uses: snok/container-retention-policy@v2
       with:
-        account-type: personal
+        account-type: org
+        org-name: andreykaipov
         token: ${{ steps.generate-token.outputs.token }}
+        token-type: github-token
         image-names: ${{ github.event.repository.name }}
         cut-off: one month ago EST
         untagged-only: true


### PR DESCRIPTION
can't use gh app generated tokens in this action :(