### PR TITLE
ci: use the latest OBS in Docker image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -16,6 +16,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
+    - run: ./script/get-latest-obs.sh docker/obs.deb
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
     - uses: docker/setup-buildx-action@v3
     - uses: docker/login-action@v3
       with:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -29,7 +29,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     - uses: docker/build-push-action@v5
       with:
-        context: "{{ defaultContext }}:docker"
+        context: ./docker
         push: true
         cache-from: type=registry,ref=${{ env.image }}:buildcache
         cache-to: type=registry,ref=${{ env.image }}:buildcache,mode=max

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -2,7 +2,6 @@ name: Image
 
 on:
   workflow_dispatch:
-  schedule: [{cron: '25 9 * * 3'}] # 9:25 on Wednesdays
   push:
     branches: [main]
     paths:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cover*.out
 cover*.html
 example.png
+docker/*.deb

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,3 +1,4 @@
 *
 !config
 !cmd.sh
+!*.deb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,10 @@
 FROM ubuntu:latest AS build
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-config dump | grep -E 'Install-(Recommends|Suggests)' | sed s/1/0 | tee /etc/apt/apt.conf.d/999norecommend
 RUN apt-get update -y
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository -y ppa:obsproject/obs-studio
-RUN apt-get update -y
-RUN apt-get install -y obs-studio
+COPY *.deb /tmp/obs.deb
+RUN dpkg -i /tmp/obs.deb || :
+RUN apt-get install -y --fix-broken
+RUN apt-get install -y qt6-wayland qt6-qpa-plugins
 RUN apt-get install -y xvfb x11vnc
 RUN apt-get install -y netcat
 RUN rm -rf /var/lib/apt/lists/*

--- a/script/bump-protocol-version.sh
+++ b/script/bump-protocol-version.sh
@@ -56,6 +56,14 @@ compare_versions() {
         echo "$next" >/tmp/.goobs.protocol.next
 }
 
+build_image() {
+        if [ -z "$CI" ]; then return; fi
+        gh workflow run image.yml
+        sleep 3
+        id=$(gh run list --workflow image.yml --event workflow_dispatch --json databaseId --jq 'first|.databaseId')
+        gh run watch "$id" --interval 10
+}
+
 bump_versions() {
         sed -i "s/$current/$next/g" version.go README.md
         make generate
@@ -65,6 +73,7 @@ bump_versions() {
 main() {
         find_versions
         compare_versions
+        build_image
         bump_versions
 }
 

--- a/script/get-latest-obs.sh
+++ b/script/get-latest-obs.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+main() {
+        path=${1?specify where you want the deb}
+
+        download_artifact >/tmp/obs.zip
+        rm -rf /tmp/obs
+        unzip -od /tmp/obs /tmp/obs.zip
+        mv /tmp/obs/*.deb "$path"
+        ls -al "$path"
+}
+
+download_artifact() {
+        repo=obsproject/obs-studio
+        id=$(gh api /repos/$repo/actions/artifacts --jq '
+                [
+                        .artifacts[]
+                        | select(
+                                .workflow_run.head_branch == "master" and
+                                (.name|contains("ubuntu")) and
+                                (.name|contains("dbgsym")|not)
+                        )
+                ]
+                | sort_by(.created_at)
+                | reverse
+                | first
+                | .id
+        ')
+        gh api "/repos/$repo/actions/artifacts/$id/zip"
+}
+
+set -eu
+main "$@"


### PR DESCRIPTION
Whenever obs-websocket releases a new minor version, the client library is auto generated, but if the minor version has new requests, the tests will fail because we're testing against the older version of the server, e.g. https://github.com/andreykaipov/goobs/pull/131

Since obs-websocket is bundled with OBS now, this PR gets the latest artifact from [obsproject/obs-studio's push workflow](https://github.com/obsproject/obs-studio/actions/workflows/push.yaml) and uses that instead of the PPA because it could be weeks until it's updated.

It also builds the image before bumping instead of on a weekly cadence. Hopefully the next time there's a minor version bump with new requests, this will automatically build the image, the generated protocol PR will be created, and the tests can pass.

~~This PR also changes the retention policy on our ghcr images (TBD).~~ No need to do this as I only remove untagged images.