### PR TITLE
fix: add missing UUIDs and fields on some resources

### DIFF
--- a/api/requests/record/xx_generated.togglerecordpause.go
+++ b/api/requests/record/xx_generated.togglerecordpause.go
@@ -13,6 +13,8 @@ func (o *ToggleRecordPauseParams) GetRequestName() string {
 // Represents the response body for the ToggleRecordPause request.
 type ToggleRecordPauseResponse struct {
 	_response
+
+	OutputPaused bool `json:"outputPaused,omitempty"`
 }
 
 // Toggles pause on the record output.

--- a/api/typedefs/typedefs.go
+++ b/api/typedefs/typedefs.go
@@ -1,6 +1,7 @@
 package typedefs
 
 type Input struct {
+	InputUuid            string `json:"inputUuid"`
 	InputName            string `json:"inputName"`
 	InputKind            string `json:"inputKind"`
 	UnversionedInputKind string `json:"unversionedInputKind"`
@@ -24,6 +25,7 @@ type OutputFlags struct {
 }
 
 type Scene struct {
+	SceneUuid  string `json:"sceneUuid"`
 	SceneIndex int    `json:"sceneIndex"`
 	SceneName  string `json:"sceneName"`
 }
@@ -43,6 +45,7 @@ type Filter struct {
 }
 
 type Transition struct {
+	TransitionUuid         string `json:"transitionUuid"`
 	TransitionConfigurable bool   `json:"transitionConfigurable"`
 	TransitionFixed        bool   `json:"transitionFixed"`
 	TransitionKind         string `json:"transitionKind"`
@@ -63,6 +66,7 @@ type SceneItem struct {
 	SceneItemIndex     int                `json:"sceneItemIndex"`
 	SceneItemLocked    bool               `json:"sceneItemLocked"`
 	SceneItemTransform SceneItemTransform `json:"sceneItemTransform"`
+	SourceUuid         string             `json:"sourceUuid"`
 	SourceName         string             `json:"sourceName"`
 	SourceType         string             `json:"sourceType"`
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/buger/jsonparser v1.1.1
 	github.com/gorilla/websocket v1.5.1
 	github.com/hashicorp/logutils v1.0.0
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mmcloughlin/profile v0.1.1
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mmcloughlin/profile v0.1.1 h1:jhDmAqPyebOsVDOCICJoINoLb/AnLBaUw58nFzxWS2w=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=

--- a/internal/generate/protocol/generate.go
+++ b/internal/generate/protocol/generate.go
@@ -151,10 +151,7 @@ func generateRequest(request *Request) (s *Statement, err error) {
 	structName = name + "Response"
 	s.Commentf("Represents the response body for the %s request.", name).Line()
 
-	respf := &ResponseField{}
-	respf.ValueName = "_response"
-	respf.ValueType = "~requests~" // internal type
-	request.ResponseFields = append(request.ResponseFields, respf)
+	augmentStructFromProtocol(structName, request)
 
 	if err := generateStructFromParams("response", s, structName, request.ResponseFields); err != nil {
 		return nil, fmt.Errorf("Failed parsing 'Returns' for request %q in category %q", name, category)
@@ -394,6 +391,24 @@ func generateRequestStatuses(enums []*Enum, filter enumFilter) {
 		}
 
 		return
+	}
+}
+
+func augmentStructFromProtocol(name string, request *Request) {
+	if strings.HasSuffix(name, "Response") {
+		respf := &ResponseField{}
+		respf.ValueName = "_response"
+		respf.ValueType = "~requests~" // internal type
+		request.ResponseFields = append(request.ResponseFields, respf)
+	}
+
+	// the protocol sometimes omits fields that are returned by the server
+	switch name {
+	case "ToggleRecordPauseResponse":
+		f := &ResponseField{}
+		f.ValueName = "outputPaused"
+		f.ValueType = "Boolean"
+		request.ResponseFields = append(request.ResponseFields, f)
 	}
 }
 

--- a/internal/sample/go.mod
+++ b/internal/sample/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mmcloughlin/profile v0.1.1 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/internal/sample/go.sum
+++ b/internal/sample/go.sum
@@ -6,6 +6,8 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mmcloughlin/profile v0.1.1 h1:jhDmAqPyebOsVDOCICJoINoLb/AnLBaUw58nFzxWS2w=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=

--- a/script/test.sh
+++ b/script/test.sh
@@ -26,6 +26,7 @@ setup() {
 }
 
 gotest() {
+        export GOOBS_LOG=error
         category="$1"
         go test -v -run="^Test_$category$" -count 1 -coverprofile=cover.out -coverpkg=./... -covermode=$covermode ./...
         awk 'NR>1' cover.out >>coverall.out


### PR DESCRIPTION
First I'm adding mapstructure to error on unused fields returned by the obs-websocket server when decoding. This only happens when debugging (i.e. when `GOOBS_LOG` is nonempty).