### PR TITLE
ci: update both indirect and direct gomod deps for /internal/sample

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     directory: /internal/sample
     schedule:
       interval: weekly
+    allow:
+      - dependency-type: all
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
might be noisy but stuff like this fails when it shouldn't https://github.com/andreykaipov/goobs/pull/157