### PR TITLE
use go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,11 @@ jobs:
         go-version-file: go.mod
     - name: make test
       run: |
+        make test.unit
         # some tests are flaky because it's running against a dockerized obs
         # instance, so just retry a few times or whatever to be certain
         for _ in $(seq 1 5); do
-          if make test; then exit; fi
+          if make test.functional; then exit; fi
         done
         exit 1
     - run: go tool cover -func coverall.out

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/andreykaipov/goobs
 
-go 1.23
+go 1.20
 
 require (
 	github.com/buger/jsonparser v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/andreykaipov/goobs
 
-go 1.22
+go 1.23
 
 require (
 	github.com/buger/jsonparser v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/andreykaipov/goobs
 
-go 1.20
+go 1.22
 
 require (
 	github.com/buger/jsonparser v1.1.1

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -1,6 +1,8 @@
 module github.com/andreykaipov/goobs/internal
 
-go 1.18
+go 1.22.0
+
+toolchain go1.22.5
 
 require (
 	github.com/dave/jennifer v1.7.1

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -1,8 +1,6 @@
 module github.com/andreykaipov/goobs/internal
 
-go 1.22.0
-
-toolchain go1.22.5
+go 1.23
 
 require (
 	github.com/dave/jennifer v1.7.1

--- a/internal/sample/go.mod
+++ b/internal/sample/go.mod
@@ -1,6 +1,6 @@
 module github.com/andreykaipov/goobs/internal/sample
 
-go 1.20
+go 1.22
 
 require (
 	github.com/andreykaipov/goobs v0.0.0

--- a/internal/sample/go.mod
+++ b/internal/sample/go.mod
@@ -1,6 +1,6 @@
 module github.com/andreykaipov/goobs/internal/sample
 
-go 1.22
+go 1.23
 
 require (
 	github.com/andreykaipov/goobs v0.0.0

--- a/script/test.sh
+++ b/script/test.sh
@@ -36,6 +36,7 @@ main() {
         set -eu
         trap cleanup EXIT
         setup
+        sleep 10
         export OBS_PORT
 
         # note: `scenes` and `transitions` must be ran after `ui`


### PR DESCRIPTION
CI is failing 🤷 

```golang.org/x/tools/internal/pkgbits: cannot compile Go 1.22 code
golang.org/x/tools/internal/tokeninternal: cannot compile Go 1.22 code
golang.org/x/mod/semver: cannot compile Go 1.22 code
golang.org/x/tools/internal/event/label: cannot compile Go 1.22 code
golang.org/x/tools/internal/stdlib: cannot compile Go 1.22 code
golang.org/x/tools/internal/aliases: cannot compile Go 1.22 code
golang.org/x/tools/internal/versions: cannot compile Go 1.22 code
```