### PR TITLE
bugfix(client): panic: send on closed channel

### DIFF
--- a/client.go
+++ b/client.go
@@ -141,7 +141,6 @@ func (c *Client) markDisconnected() {
 		c.client.Log.Printf("[TRACE] Closing internal channels")
 		close(c.IncomingEvents)
 		close(c.client.Opcodes)
-		close(c.client.IncomingResponses)
 		close(c.client.Disconnected)
 	})
 }
@@ -210,7 +209,10 @@ func (c *Client) connect() (err error) {
 	authComplete := make(chan error)
 
 	go c.handleRawServerMessages(authComplete)
-	go c.handleOpcodes(authComplete)
+	go func() {
+		c.handleOpcodes(authComplete)
+		close(c.client.IncomingResponses)
+	}()
 
 	timer := time.NewTimer(c.client.ResponseTimeout * time.Millisecond)
 	defer timer.Stop()

--- a/client.go
+++ b/client.go
@@ -32,6 +32,8 @@ type Client struct {
 	Categories
 
 	conn               *websocket.Conn
+	connWLocker        sync.Mutex
+	connRLocker        sync.Mutex
 	scheme             string
 	host               string
 	password           string
@@ -120,7 +122,7 @@ func (c *Client) Disconnect() error {
 	c.client.Log.Printf("[DEBUG] Sending disconnect message")
 	c.markDisconnected()
 
-	if err := c.conn.WriteMessage(
+	if err := c.writeMessage(
 		websocket.CloseMessage,
 		websocket.FormatCloseMessage(websocket.CloseNormalClosure, "Bye"),
 	); err != nil {
@@ -129,6 +131,15 @@ func (c *Client) Disconnect() error {
 	}
 
 	return nil
+}
+
+func (c *Client) writeMessage(messageType int, data []byte) error {
+	c.connWLocker.Lock()
+	defer c.connWLocker.Unlock()
+	return c.conn.WriteMessage(
+		messageType,
+		data,
+	)
 }
 
 func (c *Client) markDisconnected() {
@@ -224,13 +235,19 @@ func (c *Client) connect() (err error) {
 	}
 }
 
+func (c *Client) readJSON(v any) error {
+	c.connRLocker.Lock()
+	defer c.connRLocker.Unlock()
+	return c.conn.ReadJSON(v)
+}
+
 // translates raw server messages into opcodes
 func (c *Client) handleRawServerMessages(auth chan<- error) {
 	defer c.client.Log.Printf("[TRACE] Finished handling raw server messages")
 
 	for {
 		raw := json.RawMessage{}
-		if err := c.conn.ReadJSON(&raw); err != nil {
+		if err := c.readJSON(&raw); err != nil {
 			switch t := err.(type) {
 			case *json.UnmarshalTypeError:
 				c.client.Log.Printf("[ERROR] Reading from connection: %s: %s", t, raw)
@@ -325,7 +342,7 @@ func (c *Client) handleOpcodes(auth chan<- error) {
 			c.client.Log.Printf("[INFO] Identify;")
 
 			msg := opcodes.Wrap(val).Bytes()
-			if err := c.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+			if err := c.writeMessage(websocket.TextMessage, msg); err != nil {
 				auth <- fmt.Errorf("sending Identify to server `%s`: %w", msg, err)
 			}
 
@@ -356,7 +373,7 @@ func (c *Client) handleOpcodes(auth chan<- error) {
 			c.client.Log.Printf("[TRACE] Got %s Request with ID %s", val.Type, val.ID)
 
 			msg := opcodes.Wrap(val).Bytes()
-			if err := c.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+			if err := c.writeMessage(websocket.TextMessage, msg); err != nil {
 				c.client.Log.Printf("[ERROR] Sending Request to server `%s`: %s", msg, err)
 			}
 


### PR DESCRIPTION
Fix:

    panic: send on closed channel

    goroutine 751872 [running]:
    github.com/andreykaipov/goobs.(*Client).writeEvent(...)
        /home/xaionaro/.gvm/pkgsets/go1.22.1/global/pkg/mod/github.com/andreykaipov/goobs@v1.4.1/client.go:363
    github.com/andreykaipov/goobs.(*Client).handleOpcodes(0xc0020c81a0, 0xc0013846c0)
        /home/xaionaro/.gvm/pkgsets/go1.22.1/global/pkg/mod/github.com/andreykaipov/goobs@v1.4.1/client.go:338 +0x5a5
    created by github.com/andreykaipov/goobs.(*Client).connect in goroutine 751658
        /home/xaionaro/.gvm/pkgsets/go1.22.1/global/pkg/mod/github.com/andreykaipov/goobs@v1.4.1/client.go:200

Essentially by design we should close a channel only after we finished all possible writing to it. Thus moving the close statement of channel IncomingResponses to be called right after the writer to the channel is finished.