### PR TITLE
fix: Set correct types and annotations for KeyModifiers

### DIFF
--- a/api/typedefs/typedefs.go
+++ b/api/typedefs/typedefs.go
@@ -74,10 +74,10 @@ type SceneItem struct {
 type InputAudioTracks map[string]bool
 
 type KeyModifiers struct {
-	Shift   string `json:"face"`
-	Control int    `json:"flags"`
-	Alt     int    `json:"size"`
-	Command string `json:"style"`
+	Shift   bool `json:"shift"`
+	Control bool `json:"control"`
+	Alt     bool `json:"alt"`
+	Command bool `json:"command"`
 }
 
 type Monitor struct {


### PR DESCRIPTION
Fixes https://github.com/andreykaipov/goobs/issues/194

These are the correct types and annotations for KeyModifiers.

I was able to verify that this works with a small test program:

```go
	params := general.NewTriggerHotkeyByKeySequenceParams()
	params = params.WithKeyId("OBS_KEY_NUMPLUS")
	params = params.WithKeyModifiers(&typedefs.KeyModifiers{Shift: true, Control: true, Alt: true})

	if _, err := client.General.TriggerHotkeyByKeySequence(params); err != nil {
		panic(err)
	}

	time.Sleep(1 * time.Second)

	params2 := general.NewTriggerHotkeyByKeySequenceParams()
	params2 = params.WithKeyId("OBS_KEY_NUMPLUS")
	params2 = params.WithKeyModifiers(&typedefs.KeyModifiers{Shift: true, Control: true, Command: true})

	if _, err := client.General.TriggerHotkeyByKeySequence(params2); err != nil {
		panic(err)
	}
```