### PR TITLE
Fix build: Add patch version to go directive in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/andreykaipov/goobs
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/buger/jsonparser v1.1.1

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -1,6 +1,7 @@
 module github.com/andreykaipov/goobs/internal
 
-go 1.23
+go 1.23.0
+
 require (
 	github.com/dave/jennifer v1.7.1
 	github.com/fatih/structtag v1.2.0

--- a/internal/sample/go.mod
+++ b/internal/sample/go.mod
@@ -1,6 +1,6 @@
 module github.com/andreykaipov/goobs/internal/sample
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/andreykaipov/goobs v0.0.0


### PR DESCRIPTION
This PR removes the CI failures that were occurring due to:

```text
go: updates to go.mod needed; to update it:
        go mod tidy
make: *** [Makefile:13: test.unit] Error 1
```

Based on the discussion in <https://github.com/golang/go/issues/62278#issuecomment-1698829945> and the fact that this project doesn't seem to rely on any specific patch revision, I put `1.23.0` to resolve the issue.