### PR TITLE
fix(client): deprecate WithResponseTimeout in favor of WithResponseTimeoutDuration

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -103,7 +103,7 @@ func (c *Client) SendRequest(requestBody Params, responseBody Response) error {
 
 	var response *opcodes.RequestResponse
 
-	timer := time.NewTimer(c.ResponseTimeout * time.Millisecond)
+	timer := time.NewTimer(c.ResponseTimeout)
 	defer timer.Stop()
 	select {
 	case response = <-c.IncomingResponses:


### PR DESCRIPTION
The `WithResponseTimeout` option expects a number of milliseconds typed as `time.Duration`, which is not idiomatic in Go.

This PR adds a new `WithResponseTimeoutDuration` that takes a proper `time.Duration` value.

This preserves backward compatibility while fixing the semantic mismatch.