### PR TITLE
fix: use release-drafter output to publish the correct draft

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,6 +16,8 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.draft-release.outputs.tag_name }}
     steps:
     - name: draft release
       id: draft-release
@@ -50,5 +52,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       run: |
-        draft=$(gh release list | awk -F'\t' '/Draft/ {print $3}' | head -n1)
-        gh release edit "$draft" --draft=false
+        gh release edit "${{ needs.update-release-draft.outputs.tag_name }}" --draft=false


### PR DESCRIPTION
Previously, `publish-release-draft` picked the first draft from `gh release list`, which could differ from the draft that release-drafter just updated. When multiple draft releases exist (caused by race conditions from concurrent dependabot PR events), this leads to publishing a stale draft with incomplete release notes.

This is what happened with v1.8.3 — the protocol bump PR #245 was missing from the release notes.

**Root cause:** On 2026-03-09, three dependabot PRs merged within seconds. Each triggered release-drafter via both `pull_request` and `pull_request_target`, so 6 concurrent runs raced to create a draft. Three of them saw no existing draft and each created one. Later, one got renamed to `v1.9.0` (from a `minor`-labeled PR), leaving two drafts. When `publish-release-draft` ran, it grabbed the wrong one.

**Fix:** Pass the `tag_name` output from the `update-release-draft` job to `publish-release-draft`, so we always publish the exact draft that was just updated.

Also retroactively fixed the v1.8.3 release notes and deleted the stale v1.9.0 draft.