### PR TITLE
ci: serialize release-drafter runs to prevent duplicate drafts

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: release-drafter
+  cancel-in-progress: false
+
 jobs:
   update-release-draft:
     permissions:


### PR DESCRIPTION
Adds a concurrency guard to the release-drafter workflow to serialize runs. Without this, concurrent PR events can race to create duplicate draft releases — which is what happened with v1.8.3 when PRs #237 and #238 were opened simultaneously, triggering 3 concurrent release-drafter runs that each saw no existing draft and created one, resulting in duplicate `v1.8.3` drafts.