### PR TITLE
Fix permanent hang on half-open connections

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,6 +43,7 @@ type Client struct {
 	profiler           *profile.Profile
 	once               sync.Once
 	eventsMu           sync.RWMutex // Protects IncomingEvents from being closed while we send
+	writeTimeout       time.Duration
 }
 
 // Option represents a functional option of a Client.
@@ -105,6 +106,17 @@ func WithResponseTimeoutDuration(x time.Duration) Option {
 	}
 }
 
+// WithWriteTimeoutDuration sets the time we're willing to wait for a single
+// outgoing websocket write to finish before giving up on it. The default is
+// 10 seconds.
+func WithWriteTimeoutDuration(x time.Duration) Option {
+	if x <= 0 {
+		x = 10 * time.Second
+	}
+
+	return func(o *Client) { o.writeTimeout = x }
+}
+
 // WithScheme sets the protocol scheme to use when connecting to the server,
 // e.g. "ws" or "wss". The default is "ws". Please note however that the
 // obs-websocket server does not currently support connecting over wss (ref:
@@ -160,6 +172,9 @@ func (c *Client) Disconnect() error {
 func (c *Client) writeMessage(messageType int, data []byte) error {
 	c.connWLocker.Lock()
 	defer c.connWLocker.Unlock()
+	if err := c.conn.SetWriteDeadline(time.Now().Add(c.writeTimeout)); err != nil {
+		return err
+	}
 	return c.conn.WriteMessage(
 		messageType,
 		data,
@@ -191,6 +206,7 @@ func New(host string, opts ...Option) (*Client, error) {
 		dialer:             websocket.DefaultDialer,
 		requestHeader:      http.Header{"User-Agent": []string{"goobs/" + LibraryVersion}},
 		eventSubscriptions: subscriptions.All,
+		writeTimeout:       10 * time.Second,
 		client: &api.Client{
 			Disconnected:      make(chan struct{}),
 			IncomingResponses: make(chan *opcodes.RequestResponse),


### PR DESCRIPTION
writeMessage() called conn.WriteMessage() with no deadline. handleOpcodes() is a single-consumer loop that both sends outgoing requests and forwards every incoming server message into IncomingResponses/events. If the TCP connection goes half-open (server stops responding but never sends a TCP RST/FIN, e.g. after a network blip or a NAT/firewall silently dropping an idle connection), conn.WriteMessage() blocks forever with no way to detect the dead peer. Since handleOpcodes is single-threaded, that one stuck write wedges everything behind it: Opcodes is unbuffered, so no future SendRequest can even enqueue its request, and no incoming message can be processed either. The client is wedged forever with no way to recover short of killing the process.

Added a writeTimeout field (default 10s, matching the existing ResponseTimeout default) and set it as a write deadline via conn.SetWriteDeadline() before every conn.WriteMessage() call in writeMessage() -- covers the Request, Identify, and Close message paths, since they all go through this one function. A hung write now fails within writeTimeout instead of blocking forever, letting handleOpcodes's loop continue and letting SendRequest's own existing ResponseTimeout logic fire as designed. Added WithWriteTimeoutDuration to make it configurable, following the existing WithResponseTimeoutDuration pattern.

Does not add auto-reconnect or change handleOpcodes's existing error handling on write failure -- consumers are already expected to detect a dead client and create a new one, same as elsewhere in this library.