### PR TITLE
ci: prevent dependabot multi-module race for linked go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,22 @@
 ---
 version: 2
 updates:
+  # The root module and /internal/sample are linked via a `replace` directive,
+  # so any shared dependency (e.g. jsonparser) MUST be bumped in both go.mod
+  # files atomically. Using `directories:` (plural) tells dependabot to open a
+  # single PR spanning both modules instead of two racing PRs.
   - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: weekly
-  - package-ecosystem: gomod
-    directory: /internal
-    schedule:
-      interval: weekly
-  - package-ecosystem: gomod
-    directory: /internal/sample
+    directories:
+      - /
+      - /internal/sample
     schedule:
       interval: weekly
     allow:
       - dependency-type: all
+  - package-ecosystem: gomod
+    directory: /internal
+    schedule:
+      interval: weekly
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         filters: |
           go:
           - '**/*.go'
-          - go.mod
-          - go.sum
+          - '**/go.mod'
+          - '**/go.sum'
 
   test:
     needs: check-changes
@@ -49,6 +49,24 @@ jobs:
     - uses: magnetikonline/action-golang-cache@v5
       with:
         go-version-file: go.mod
+    - name: Verify go.mod is tidy in all modules
+      run: |
+        set -e
+        for dir in . internal internal/sample; do
+          (
+            cd "$dir"
+            cp go.mod go.mod.bak
+            cp go.sum go.sum.bak
+            go mod tidy
+            if ! diff -q go.mod go.mod.bak || ! diff -q go.sum go.sum.bak; then
+              echo "::error::go.mod/go.sum in $dir is not tidy; run 'go mod tidy' in that directory"
+              diff -u go.mod.bak go.mod || true
+              diff -u go.sum.bak go.sum || true
+              exit 1
+            fi
+            rm go.mod.bak go.sum.bak
+          )
+        done
     - name: make test
       run: |
         make test.unit


### PR DESCRIPTION
## Context

While debugging why #258 was failing, we found a subtle race in how dependabot handles this repo's multi-module layout.

The repo has three go modules:
- `/` (root)
- `/internal`
- `/internal/sample` — linked back to root via `replace github.com/andreykaipov/goobs => ../../`

Because root and `internal/sample` share dependencies transitively via that `replace`, any shared upstream bump (e.g. `jsonparser`) has to land in both `go.mod` files together. Dependabot didn't know that and opened two independent PRs per bump.

## What went wrong with #258 / #259

1. Dependabot opened #258 (root) and #259 (`internal/sample`) for the same `jsonparser 1.2.0 → 1.6.1` bump.
2. #259 only changed `internal/sample/go.{mod,sum}`. The CI `check-changes` path filter only matched root-level `go.mod`/`go.sum`, so `test` and `generate` were **skipped**, and automerge merged #259 without ever running a test.
3. #258's branch was created before #259 landed, so its snapshot of `internal/sample/go.mod` was now stale relative to `main`.
4. When #258's CI ran the sample tests, `go` computed the effective transitive version through the `replace` and errored with `go: updates to go.mod needed; to update it: go mod tidy`.

## Changes

### `.github/dependabot.yml`
Bundle root and `/internal/sample` under one dependabot entry using the `directories:` (plural) form. A shared bump now produces **one atomic PR** touching both `go.mod` files — no race, nothing to go stale. `/internal` stays on its own entry since it's an independent module.

### `.github/workflows/ci.yml`
- Broaden the paths filter to `**/go.mod` and `**/go.sum` so submodule-only PRs actually run tests instead of getting `test: skipping` and auto-merging blind.
- Add a "go mod tidy" verification step that runs across all three modules and fails fast with a clear message if anything drifts. This turns the current cryptic mid-test failure into an immediate, obvious signal.

## Follow-up

Once this merges, #258 should be rebased (already commented `@dependabot rebase`); future shared bumps will come through as a single PR.