### PR TITLE
ci: skip release-drafter pull_request run for fork PRs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,6 +16,13 @@ concurrency:
 
 jobs:
   update-release-draft:
+    # Fork PRs get a read-only GITHUB_TOKEN on the `pull_request` trigger, so
+    # release-drafter's "Create a release" API call 403s. The `pull_request_target`
+    # trigger already handles fork PRs with the base repo's write token, so the
+    # `pull_request` run is redundant and only produces noise. Skip it for forks.
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Context

Fork PRs (like #256) show a failing `update-release-draft` check because the `pull_request` trigger runs with a read-only `GITHUB_TOKEN` on fork PRs, and release-drafter's "Create a release" API call 403s:

```
##[error]Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release
```

Example failure: https://github.com/andreykaipov/goobs/actions/runs/28900624275/job/85736252893

## Why the draft is still fine

The workflow already triggers on `pull_request_target` as well, which runs with the **base** repo's token and successfully updates the draft even for fork PRs. You can see this on #256 -- there are two `update-release-draft` check entries, one failing (from `pull_request`) and one passing (from `pull_request_target`). The draft release is being kept up to date correctly by the passing one; the failing one is pure noise.

## Change

Add an `if:` guard on `update-release-draft` that skips the job when:
- the event is `pull_request` (not `pull_request_target`, not `workflow_dispatch`), AND
- the PR head repo is different from the base repo (i.e. it's a fork).

```yaml
if: >
  github.event_name != 'pull_request' ||
  github.event.pull_request.head.repo.full_name == github.repository
```

Same-repo PRs behave identically to before. Fork PRs will now only run `update-release-draft` via `pull_request_target`, which is the trigger that actually has permission to draft releases.

## Considered alternative

I considered dropping the `pull_request` trigger entirely and relying solely on `pull_request_target`, but the `publish-release-draft` job's condition (`github.event_name == 'pull_request' && github.event.action == 'closed'`) would need updating too, and the risk/blast-radius of that is larger for zero additional benefit. The surgical `if:` guard fixes the reported problem without touching anything else.