### PR TITLE
ci: fire release-drafter on fork PR merge via pull_request_target

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, closed]
 
 permissions:
   contents: read


### PR DESCRIPTION
## The bug

Follow-up to #265. That PR added an `if:` guard on `update-release-draft` that skips the `pull_request` trigger for fork PRs (to avoid the 403 from release-drafter's create-release API call under a read-only fork `GITHUB_TOKEN`).

The intent was: fork PRs would fall through to the `pull_request_target` trigger, which runs with the base repo's write token.

But `pull_request_target` was only listening for `[opened, reopened, synchronize]` — not `closed`. So when a fork PR was merged:

1. `pull_request: closed` fires
2. `if:` guard from #265 correctly skips the job (fork PR, read-only token)
3. `pull_request_target: closed` doesn't fire (not in activity types)
4. **Nothing updates the draft.** Fork PR sits merged, invisible to the draft.

This was hit immediately: #256 merged at 02:55 UTC; the draft still showed `v1.10.0` without any Features section until I manually `workflow_dispatch`ed `update-release-draft`. See run [`32326361558`](https://github.com/andreykaipov/goobs/actions/runs/32326361558) (the `pull_request closed` run that got skipped) and run [`32326733535`](https://github.com/andreykaipov/goobs/actions/runs/32326733535) (the manual fix).

## Fix

Add `closed` to `pull_request_target`'s activity types.

For same-repo PRs, both triggers fire on close and the existing `concurrency:` group serializes them (they idempotently update the same draft). For fork PR merges, `pull_request_target: closed` now fires with write permission and updates the draft.

## Also considered

Reverting the `if:` guard from #265 entirely would also solve this (fork PRs would go back to the harmless red X). But then we'd re-introduce the ugly failing check on fork PRs. Keeping the guard and adding the missing `closed` type is the smaller, more targeted fix.